### PR TITLE
Fix/drop too common tree nodes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -185,7 +185,7 @@ function recursivelyBuildPkgTree(
       lockedVersions,
       projectRootPath,
       pkg.from,
-      Object.assign({}, pkg._counts)
+      shallowCopyMap(pkg._counts)
     );
 
     pkg._counts = sumCounts(pkg._counts, child._counts);
@@ -207,13 +207,23 @@ function recursivelyBuildPkgTree(
 }
 
 function sumCounts(a, b) {
-  var sum = Object.assign({}, a);
+  var sum = shallowCopyMap(a);
 
   for (var k in b) {
     sum[k] = (sum[k] ? (sum[k] + b[k]) : b[k])
   }
 
   return sum;
+}
+
+function shallowCopyMap(m) {
+  var copy = {};
+
+  for (var k in m) {
+    copy[k] = m[k]
+  }
+
+  return copy;
 }
 
 function isProjSubpackage(pkgPath, projectRootPath) {


### PR DESCRIPTION
This is probably a temporary fix, but is quite urgent as currently the plugin crashes with OutOfMemory when some popular (and big) packages are imported. e.g this will crash:

```go
package main

import (
	_ "k8s.io/client-go/kubernetes"
)

func main() {
	println("koko")
}
```

The fix removes nodes that are very common from the result tree, however it does it while ensuring that every dependency has at-least onc path to it 