### PR TITLE
Fix/tree reduction bugfix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -167,13 +167,14 @@ function recursivelyBuildPkgTree(
     pkg.from = pkg.from.concat(pkg.name + '@' + pkg.version)
   }
 
-  pkg._counts = counts;
+  pkg._counts = {};
 
   var children = graph.successors(node.Name);
   children.forEach(function (depName) {
+
     // We drop branches of overly common pkgs:
     // this looses some paths, but avoids explosion in result size
-    if (pkg._counts[depName] > 50) {
+    if ((counts[depName] || 0) + (pkg._counts[depName] || 0)  > 50) {
       return;
     }
 
@@ -185,7 +186,7 @@ function recursivelyBuildPkgTree(
       lockedVersions,
       projectRootPath,
       pkg.from,
-      shallowCopyMap(pkg._counts)
+      sumCounts(counts, pkg._counts)
     );
 
     pkg._counts = sumCounts(pkg._counts, child._counts);
@@ -198,8 +199,7 @@ function recursivelyBuildPkgTree(
     } else {
       pkg.dependencies[child.name] = child;
 
-      pkg._counts[child.name] =
-        (pkg._counts[child.name] ? pkg._counts[child.name] + 1 : 1);
+      pkg._counts[child.name] = (pkg._counts[child.name] || 0) + 1;
     }
   })
 
@@ -210,7 +210,7 @@ function sumCounts(a, b) {
   var sum = shallowCopyMap(a);
 
   for (var k in b) {
-    sum[k] = (sum[k] ? (sum[k] + b[k]) : b[k])
+    sum[k] = (sum[k] || 0) + b[k];
   }
 
   return sum;

--- a/lib/index.js
+++ b/lib/index.js
@@ -174,7 +174,7 @@ function recursivelyBuildPkgTree(
 
     // We drop branches of overly common pkgs:
     // this looses some paths, but avoids explosion in result size
-    if ((counts[depName] || 0) + (pkg._counts[depName] || 0)  > 50) {
+    if ((counts[depName] || 0) + (pkg._counts[depName] || 0)  > 10) {
       return;
     }
 
@@ -194,7 +194,11 @@ function recursivelyBuildPkgTree(
 
     if (child._isProjSubpkg) {
       Object.keys(child.dependencies).forEach(function (grandChildName) {
-        pkg.dependencies[grandChildName] = child.dependencies[grandChildName];
+        // don't merge grandchild if already a child,
+        // because it was traversed with higher counts and may be more partial
+        if (!pkg.dependencies[grandChildName]) {
+          pkg.dependencies[grandChildName] = child.dependencies[grandChildName];
+        }
       });
     } else {
       pkg.dependencies[child.name] = child;


### PR DESCRIPTION
There were 2 bugs:
1.  each child initiated it's own counts from the counts passed from parent
2. when merging root-subpkgs need to carefully not overwrite existing child as the grandchild was scanned later and may have less nodes