### PR TITLE
chore: add github.com/KyleBanks/depth MIT license

### DIFF
--- a/gosrc/deps-tree.go
+++ b/gosrc/deps-tree.go
@@ -1,3 +1,28 @@
+/*
+	This code is based on https://github.com/KyleBanks/depth
+
+MIT License
+
+Copyright (c) 2017 Kyle Banks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 package main
 
 import (
@@ -11,10 +36,6 @@ import (
 	"sort"
 	"strings"
 )
-
-/*
-	This code is based on https://github.com/KyleBanks/depth
-*/
 
 // Pkg represents a Go source package, and its dependencies.
 type Pkg struct {


### PR DESCRIPTION
the code under `gosrc/deps-tree.go` is based on https://github.com/KyleBanks/depth which is MIT licensed
