### PR TITLE
fix: dirwalk: skip dirs starting with _

### DIFF
--- a/gosrc/resolver/dirwalk/dirwalk.go
+++ b/gosrc/resolver/dirwalk/dirwalk.go
@@ -23,7 +23,8 @@ func WalkGoFolders(root string, cb WalkFunc) error {
 			return filepath.SkipDir
 		}
 		if strings.HasSuffix(folderName, "_test") ||
-			(folderName != "." && strings.HasPrefix(folderName, ".")) {
+			(folderName != "." && strings.HasPrefix(folderName, ".")) ||
+			strings.HasPrefix(folderName, "_") {
 			return filepath.SkipDir
 		}
 

--- a/test/fixtures/gopath/src/path/to/multiroot-pkg/shouldskip/_underscore_folder/main.go
+++ b/test/fixtures/gopath/src/path/to/multiroot-pkg/shouldskip/_underscore_folder/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	_ "dummy.org/should/skip/underscore/folder"
+)
+
+func main() {
+	println("go")
+}


### PR DESCRIPTION
to better resemble the behaviour of dep:
https://github.com/golang/dep/blob/80e94e8eef3660a2cd9d80b64ae95d7c898e8453/gps/pkgtree/reachmap.go#L26