### PR TITLE
fix: better suggest `govendor` users to run `sync`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -112,7 +112,7 @@ var PACKAGE_MANAGER_BY_TARGET = {
 
 var VENDOR_SYNC_CMD_BY_PKG_MANAGER = {
   dep: 'dep ensure',
-  govendor: 'govendor fetch +outside',
+  govendor: 'govendor sync',
 }
 
 function pkgManagerByTarget(targetFile) {

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -567,7 +567,7 @@ test('missing some packages in vendor/ folder (govendor)', function (t) {
         'Unresolved packages:\n' +
         ' -  gitpub.com/nature/vegetables/cucamba\n' +
         ' -  gitpub.com/nature/vegetables/tomato\n' +
-        '\nUnresolved imports found, please run `govendor fetch +outside`');
+        '\nUnresolved imports found, please run `govendor sync`');
     });
 });
 


### PR DESCRIPTION
instead of `fetch +outside`