### PR TITLE
add go files as Zeit assets, dump them to disk and run

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var toml = require('toml');
 var graphlib = require('graphlib');
+var tmp = require('tmp');
 
 var subProcess = require('./sub-process');
 
@@ -9,9 +10,11 @@ module.exports = {
   inspect: inspect,
 };
 
-var VIRTUAL_ROOT_NODE_ID = '.'
+var VIRTUAL_ROOT_NODE_ID = '.';
 
 function inspect(root, targetFile, options) {
+  
+  
   return Promise.all([
     getMetaData(root, targetFile),
     getDependencies(root, targetFile),
@@ -30,7 +33,7 @@ function getMetaData(root, targetFile) {
     var runtime;
     versionMatch = /(go\d+\.?\d+?\.?\d*)/.exec(output);
     if (versionMatch) {
-      runtime = versionMatch[0]
+      runtime = versionMatch[0];
     }
 
     return {
@@ -41,14 +44,79 @@ function getMetaData(root, targetFile) {
   });
 }
 
+// Hack:
+// We're using Zeit assets feature in order to support Python and Go testing 
+// within a binary release. By doing "path.join(__dirname, 'PATH'), Zeit adds
+// PATH file auto to the assets. Sadly, Zeit doesn't support (as far as I
+// understand) adding a full folder as an asset, and this is why we're adding
+// the required files this way. In addition, Zeit doesn't support 
+// path.resolve(), and this is why I'm using path.join()
+function createAssets(){
+  assets = [];
+  assets.push(path.join(__dirname, '../gosrc/resolve-deps.go'));
+  assets.push(path.join(__dirname, '../gosrc/resolver/pkg.go'));
+  assets.push(path.join(__dirname, '../gosrc/resolver/resolver.go'));
+  assets.push(path.join(__dirname, '../gosrc/resolver/dirwalk/dirwalk.go'));
+  assets.push(path.join(__dirname, '../gosrc/resolver/graph/graph.go'));
+
+  return assets;
+}
+
+function writeFile(writeFilePath, contents) {
+  var dirPath = path.dirname(writeFilePath);
+  if (!fs.existsSync(dirPath))
+  {
+    fs.mkdirSync(dirPath);
+  }
+  fs.writeFileSync(writeFilePath, contents);
+}
+
+function getFilePathRelativeToDumpDir(filePath) {
+  var pathParts = filePath.split('\\gosrc\\');
+
+  // Windows
+  if (pathParts.length > 1)
+  {
+    return pathParts[1];
+  }
+
+  // Unix
+  pathParts = filePath.split('/gosrc/');
+  return pathParts[1];  
+}
+
+function dumpAllResolveDepsFilesInTempDir(tempDirName) {
+  createAssets().forEach(function(currentReadFilePath) {
+    if (!fs.existsSync(currentReadFilePath))
+    {
+      throw new Error('The file `' + currentReadFilePath + '` is missing');
+    }
+    
+    var relFilePathToDumpDir = 
+      getFilePathRelativeToDumpDir(currentReadFilePath);
+    
+    var writeFilePath = path.join(tempDirName, relFilePathToDumpDir);
+
+    var contents = fs.readFileSync(currentReadFilePath);
+    writeFile(writeFilePath, contents);
+  });
+}
+
 function getDependencies(root, targetFile) {
   var config;
+  var tempDirObj;
   return new Promise(function (resolve, reject) {
     config = parseConfig(root, targetFile);
     resolve(config);
   }).then(function () {
-    var goResolveTool = path.join(__dirname, '..', 'gosrc', 'resolve-deps.go')
-
+    tempDirObj = tmp.dirSync({
+      unsafeCleanup: true
+    });
+  
+    dumpAllResolveDepsFilesInTempDir(tempDirObj.name);
+  
+    var goResolveTool = 
+      path.join(tempDirObj.name, 'resolve-deps.go');
     var ignorePkgsParam;
     if (config.ignoredPkgs && config.ignoredPkgs.length > 0) {
       ignorePkgsParam = '-ignoredPkgs=' + config.ignoredPkgs.join(',');
@@ -57,8 +125,9 @@ function getDependencies(root, targetFile) {
       'go',
       ['run', goResolveTool, ignorePkgsParam],
       { cwd: root }
-    )
+    );
   }).then(function (graph) {
+    tempDirObj.removeCallback();
     graph = JSON.parse(graph);
     graph = graphlib.json.read(graph);
 
@@ -71,7 +140,7 @@ function getDependencies(root, targetFile) {
     // i.e. pkgs with no local dependants.
     // To create a tree, we add edges from a "virutal root",
     // to these source nodes.
-    var VIRTUAL_ROOT_NODE_ID = '.'
+    var VIRTUAL_ROOT_NODE_ID = '.';
     var root = graph.node(VIRTUAL_ROOT_NODE_ID);
     if (!root) {
       throw new Error('Failed parsing dependency graph');
@@ -79,7 +148,7 @@ function getDependencies(root, targetFile) {
 
     graph.sources().forEach(function (nodeId) {
       if (nodeId != VIRTUAL_ROOT_NODE_ID) {
-        graph.setEdge(VIRTUAL_ROOT_NODE_ID, nodeId)
+        graph.setEdge(VIRTUAL_ROOT_NODE_ID, nodeId);
       }
     });
 
@@ -93,6 +162,7 @@ function getDependencies(root, targetFile) {
 
     return pkgsTree;
   }).catch(function (error) {
+    tempDirObj.removeCallback();
     if (typeof error === 'string') {
       var unresolvedOffset = error.indexOf('Unresolved packages:');
       if (unresolvedOffset !== -1) {
@@ -115,7 +185,7 @@ var PACKAGE_MANAGER_BY_TARGET = {
 var VENDOR_SYNC_CMD_BY_PKG_MANAGER = {
   dep: 'dep ensure',
   govendor: 'govendor sync',
-}
+};
 
 function pkgManagerByTarget(targetFile) {
   var fname = path.basename(targetFile);
@@ -161,7 +231,7 @@ function recursivelyBuildPkgTree(
   var pkg = {
     name: (isRoot ? node.FullImportPath : node.Name),
     dependencies: {},
-  }
+  };
   if (!isRoot && isProjSubpkg) {
     pkg._isProjSubpkg = true;
   }
@@ -214,7 +284,7 @@ function recursivelyBuildPkgTree(
         pkg._counts[child.name] = (pkg._counts[child.name] || 0) + 1;
       }
     }
-  })
+  });
 
   return pkg;
 }
@@ -233,7 +303,7 @@ function shallowCopyMap(m) {
   var copy = {};
 
   for (var k in m) {
-    copy[k] = m[k]
+    copy[k] = m[k];
   }
 
   return copy;
@@ -262,9 +332,10 @@ function isProjSubpackage(pkgPath, projectRootPath) {
 
 function parseConfig(root, targetFile) {
   var pkgManager = pkgManagerByTarget(targetFile);
+  var config = {};
   switch (pkgManager) {
     case 'dep': {
-      var config = {
+      config = {
         ignoredPkgs: [],
         lockedVersions: {},
       };
@@ -289,7 +360,7 @@ function parseDepLock(root, targetFile) {
   try {
     var lock = fs.readFileSync(path.join(root, targetFile));
 
-    var lockJson = toml.parse(String(lock))
+    var lockJson = toml.parse(String(lock));
 
     var deps = {};
     lockJson.projects && lockJson.projects.forEach(function (proj) {
@@ -304,7 +375,7 @@ function parseDepLock(root, targetFile) {
         var dep = {
           name: name,
           version: version,
-        }
+        };
 
         deps[dep.name] = dep;
       });
@@ -317,8 +388,8 @@ function parseDepLock(root, targetFile) {
 }
 
 function parseDepManifest(root, targetFile) {
-  var manifestDir = path.dirname(path.join(root, targetFile))
-  var manifestPath = path.resolve(path.join(manifestDir, 'Gopkg.toml'))
+  var manifestDir = path.dirname(path.join(root, targetFile));
+  var manifestPath = path.resolve(path.join(manifestDir, 'Gopkg.toml'));
 
   try {
     var manifestToml = fs.readFileSync(manifestPath);
@@ -352,7 +423,7 @@ function parseGovendorJson(root, targetFile) {
       var dep = {
         name: pkg.path,
         version: version,
-      }
+      };
 
       config.lockedVersions[dep.name] = dep;
     });
@@ -365,7 +436,7 @@ function parseGovendorJson(root, targetFile) {
       pkgName = pkgName.replace(/\/+$/, ''); // remove trailing /
       config.ignoredPkgs.push(pkgName);
       config.ignoredPkgs.push(pkgName + '/*');
-    })
+    });
 
     return config;
   } catch (e) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "graphlib": "^2.1.1",
-    "toml": "^2.3.2"
+    "toml": "^2.3.2",
+    "tmp": "0.0.33"
   },
   "devDependencies": {
     "jscs": "^3.0.7",


### PR DESCRIPTION
What does this PR do?
Adding assets to the binary release (by path.join(__dirname,PATH))
Dump all of the files to the disk (temp folder)
Execute the go script (resolve-deps.go) from the temp dir

This is the new behaviour of the plugin regarding if it run as binary \ not

How should this be manually tested?
No auto tests were added.
Manually tested "pkg ." (Zeit) with node 8 on the following os:
-Mac
-Windows

Any background context you want to provide?
Trying to avoid creating a docker img for python, we realised it might be faster to use Zeit binary release as a proper solution