### PR TITLE
fix: added missing check in error handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,9 @@ function getDependencies(root, targetFile) {
 
     return pkgsTree;
   }).catch(function (error) {
-    tempDirObj.removeCallback();
+    if (tempDirObj) {
+      tempDirObj.removeCallback();
+    }
     if (typeof error === 'string') {
       var unresolvedOffset = error.indexOf('Unresolved packages:');
       if (unresolvedOffset !== -1) {


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Added missing check in error handler.

Output from CLI before:

```
Testing /Users/kirill/Work/golang-app...

Cannot read property 'removeCallback' of undefined
```

Output from CLI after:

```
Testing /Users/kirill/Work/golang-app...

failed parsing Gopkg.toml: ENOENT: no such file or directory, open '/Users/kirill/Work/golang-app/Gopkg.toml'
```
