### PR TITLE
refactor: reuse the logic from snyk-go-parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 notifications:
   email: false
@@ -23,7 +23,7 @@ jobs:
       node_js: "8"
       script: skip
       after_success:
-        - npm run semantic-release
+        - npx semantic-release
 branches:
   only:
     - master

--- a/package.json
+++ b/package.json
@@ -17,21 +17,20 @@
     "test-functional-windows": "tap -R spec --timeout=300 ./test/*.test.ts -g \"^(?!.*symlink)\"",
     "test-system-windows": "tap -R spec --timeout=300 ./test/system/*.test.ts -g \"^(?!.*prometheus)\"",
     "test-windows": "npm run test-functional-windows && npm run test-system-windows",
-    "semantic-release": "semantic-release",
     "watch": "nodemon -e 'js go'  -x 'npm run test-functional'"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
     "graphlib": "^2.1.1",
-    "toml": "^2.3.2",
-    "tmp": "0.0.33"
+    "snyk-go-parser": "^1.0.0",
+    "tmp": "0.0.33",
+    "toml": "^2.3.2"
   },
   "devDependencies": {
     "@types/graphlib": "^2.1.4",
     "@types/node": "^6.14.4",
     "@types/tmp": "^0.1.0",
-    "semantic-release": "^15",
     "tap": "^12.6.1",
     "tap-only": "0.0.5",
     "ts-node": "^8.0.3",

--- a/test/manual.ts
+++ b/test/manual.ts
@@ -1,4 +1,5 @@
 import * as plugin from '../lib';
+import * as path from 'path';
 
 function main() {
   var targetFile = process.argv[2];

--- a/test/with-symlink.test.ts
+++ b/test/with-symlink.test.ts
@@ -16,10 +16,9 @@ test('with nested GOPATH/src/proj symlink-ing to ../..', (t) => {
   //  because node's process.chdir() resolved symlinks,
   //  such that process.cwd() no-longer contains the /gopath/ part
   return subProcess.execute(
-    `cd ${cwd} ; export GOPATH=${gopath} ; ts-node ${manualScriptPath} Gopkg.lock`,
+    `cd '${cwd}' ; export GOPATH=${gopath} ; ${__dirname}/../node_modules/.bin/ts-node ${manualScriptPath} Gopkg.lock`,
     [])
     .then((result) => {
-      console.log(result);
       const resultJson = JSON.parse(result);
 
       const plugin = resultJson.plugin;
@@ -74,5 +73,6 @@ test('with nested GOPATH/src/proj symlink-ing to ../..', (t) => {
 
         t.end();
       });
-    });
+    })
+    .catch(t.threw);
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Supersedes https://github.com/snyk/snyk-go-plugin/pull/36

Since the manifest parsing logic has now been separated into snyk-go-parser, it makes sense for the plugin to re-use that.
Drive-by: robustify tests, clean up the build script.

#### How should this be manually tested?
Scanning Go projects via CLI.

