### PR TITLE
fix: lock go parser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "graphlib": "^2.1.1",
-    "snyk-go-parser": "^1.0.0",
+    "snyk-go-parser": "1.0.0",
     "tmp": "0.0.33",
     "toml": "^2.3.2"
   },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

parser release: https://github.com/snyk/snyk-go-parser/releases/tag/v1.0.0