### PR TITLE
Fix/ts

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -28,7 +28,6 @@ interface CountDict {
 }
 
 export async function inspect(root, targetFile) {
-
   const result = await Promise.all([
     getMetaData(root, targetFile),
     getDependencies(root, targetFile),

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,5 @@
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
-import * as toml from 'toml';
 import * as graphlib from 'graphlib';
 import * as tmp from 'tmp';
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/snyk/snyk-go-plugin"
   },
-  "main": "dist/lib/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
     "lint": "tslint --project tsconfig.json --format stylish",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "graphlib": "^2.1.1",
     "snyk-go-parser": "1.0.0",
-    "tmp": "0.0.33",
-    "toml": "^2.3.2"
+    "tmp": "0.0.33"
   },
   "devDependencies": {
     "@types/graphlib": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "build-watch": "tsc -w",
     "lint": "tslint --project tsconfig.json --format stylish",
     "prepare": "npm run build",
     "test-functional": "tap ./test/*.test.ts -R spec",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

typescript generates `dist/index.js` but `"main"` property in `package.json` pointed to `dist/lib/index.js`, making this non-importable. 

