### PR TITLE
fix: proper parsing of gomodules targetFile

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -125,7 +125,7 @@ const VENDOR_SYNC_CMD_BY_PKG_MANAGER: {[k in GoPackageManagerType]: string} = {
 
 async function getDependencies(root, targetFile) {
   let tempDirObj;
-  const packageManager = PACKAGE_MANAGER_BY_TARGET[targetFile];
+  const packageManager = pkgManagerByTarget(targetFile);
   if (packageManager === 'gomodules') {
     return buildDepTreeFromImportsAndModules(root);
   }


### PR DESCRIPTION


- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
At the moment, the targetFile is not properly parsed, as targetFile can be a path, e.g. "/project/go.mod". In this case line 128 would not result in "gomodules", although this is desired.

#### Where should the reviewer start?


#### How should this be manually tested?
`snyk test --file=project/go.mod`

#### Any background context you want to provide?
At the moment, `snyk test --file=` with a path, results in '/project/go.mod' not supported, while this is already supported.

#### What are the relevant tickets?


#### Screenshots


#### Additional questions
