### PR TITLE
fix: default name, unknown version, name from main

### DIFF
--- a/test/fixtures/golist/empty/expected-tree.json
+++ b/test/fixtures/golist/empty/expected-tree.json
@@ -1,5 +1,5 @@
 {
-    "name": ".",
-    "version": "unknown",
+    "name": "empty",
+    "version": "0.0.0",
     "packageFormatVersion": "golang:0.0.1"
 }

--- a/test/fixtures/golist/import/expected-tree.json
+++ b/test/fixtures/golist/import/expected-tree.json
@@ -1,5 +1,5 @@
 {
   "name": "github.com/snyk/go-deps-resolver",
-  "version": "unknown",
+  "version": "0.0.0",
   "packageFormatVersion": "golang:0.0.1"
 }

--- a/test/fixtures/gomod-small/expected-tree.json
+++ b/test/fixtures/gomod-small/expected-tree.json
@@ -1,6 +1,6 @@
 {
     "name": "github.com/antonmedv/expr",
-    "version": "unknown",
+    "version": "0.0.0",
     "packageFormatVersion": "golang:0.0.1",
     "dependencies": {
         "golang.org/x/text/width": {


### PR DESCRIPTION
For the default name, basepath is more suitable then just dot. Version
is better 0.0.0 than unknown and project name can be taken from main
module path.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Some minor fixes for better name and version.

#### How should this be manually tested?
Running `snyk monitor` agains `go.mod` project and checking the result.

#### Additional info
https://github.com/snyk/snyk-go-plugin/compare/fix/name-and-version?expand=1#diff-13b5b151431c7e7a17f273559ed212d5R476 is awful, but I can't think of anything better (without using lodash). Feel free to suggest changes.
