### PR TITLE
fix: improve error messages for go modules

### DIFF
--- a/lib/errors/custom-error.ts
+++ b/lib/errors/custom-error.ts
@@ -1,0 +1,15 @@
+export class CustomError extends Error {
+  public innerError;
+  public code: number | undefined;
+  public userMessage: string | undefined;
+  public strCode: string | undefined;
+
+  constructor(message: string) {
+    super(message);
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.code = undefined;
+    this.innerError = undefined;
+    this.userMessage = undefined;
+  }
+}

--- a/test/fixtures/gomod-small-failing/go.mod
+++ b/test/fixtures/gomod-small-failing/go.mod
@@ -1,0 +1,13 @@
+module github.com/antonmedv/expr
+
+go 1.12
+
+require (
+	github.com/antlr/antlr4 v0.0.0-20190518164840-edae2a1c9b4b
+	github.com/gdamore/tcell v1.1.2
+	github.com/rivo/tview v0.0.0-20190515161233-bd836ef13b4b
+	github.com/sanity-io/litter v1.1.0
+	github.com/stretchr/testify v1.3.0
+	golang.org/x/text v0.3.2
+	invalid 1.2.3
+)

--- a/test/inspect.test.ts
+++ b/test/inspect.test.ts
@@ -757,6 +757,23 @@ if (goVersion[0] > 1 || goVersion[1] >= 12) {
       t.deepEquals(pkg, expectedDepTree);
     });
   });
+
+  test('invalid go.mod', {timeout: 120000}, async (t) => {
+
+    process.chdir(
+      path.resolve.apply(
+        null,
+        [__dirname, 'fixtures', 'gomod-small-failing'],
+      ),
+    );
+
+    try {
+      await plugin.inspect('.', 'go.mod');
+    } catch (e) {
+      t.match(e.message, 'go: errors parsing go.mod');
+      t.match(e.userMessage, '\'go list -json -deps ./...\' command failed with error');
+    }
+  });
 }
 
 function chdirToPkg(pkgPathArray) {


### PR DESCRIPTION
Added new gomod-small-failing test fixture - with invalid go.mod
Added inspect test for expected error messages when 'go list' fails
Added custom error class
Throw custom error from when 'go list' fails

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Fix error messages for go modules when 'go list' fails

#### How should this be manually tested?
npm run test

#### Any background context you want to provide?
https://snyk.slack.com/archives/CGV4DV5R7/p1568833750016600

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/BST-883

#### Screenshots
new example error message:
![Screenshot 2019-10-01 at 17 20 47](https://user-images.githubusercontent.com/6598617/65980846-d9515680-e46f-11e9-8dae-64d061af9b30.png)