### PR TITLE
Test/go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ node_js:
   - "8"
   - "6"
 env:
-  - GO_VERSION=1.9.5
-  - GO_VERSION=1.10.1
-  - GO_VERSION=1.12.4
+  - GO_VERSION=1.10.8
+  - GO_VERSION=1.12.12
+  - GO_VERSION=1.13.3
 cache:
   directories:
     - node_modules

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -483,7 +483,7 @@ export async function buildDepTreeFromImportsAndModules(root: string = '.') {
 
   const localPackages = goDeps.filter((gp) => !gp.DepOnly);
   const localPackageWithMainModule = localPackages
-      .find((localPackage) => (localPackage.Module && localPackage.Module.Main));
+      .find((localPackage) => !!(localPackage.Module && localPackage.Module.Main));
   if (localPackageWithMainModule && localPackageWithMainModule!.Module!.Path) {
     depTree.name = localPackageWithMainModule!.Module!.Path;
   }


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Go 1.13 introduced some changes to how GOPATH is handled (https://golang.org/doc/go1.13#modules), so worth updating our test matrix with this version.
To not increase the matrix, replacing 1.9.x with 1.10.x.
Not going straight for 1.11.x to keep a pre-go-modules version in the matrix.

This PR also fixes a typescript compilation error.

##### the new matrix:
<img width="1031" alt="image" src="https://user-images.githubusercontent.com/4750004/67035948-55f85c00-f123-11e9-9a40-ab2b00d38594.png">
