### PR TITLE
test: add go 1.14 to test matrix (replacing 1.12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ node_js:
   - "6"
 env:
   - GO_VERSION=1.10.8
-  - GO_VERSION=1.12.12
   - GO_VERSION=1.13.3
+  - GO_VERSION=1.14.0
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Go 1.14 was released with various changes to `go modules` mentioned in the release notes: https://golang.org/doc/go1.14

this PR makes sure it's in the test matrix

![image](https://user-images.githubusercontent.com/4750004/75325557-b8a3f600-5881-11ea-852c-1922ac6d4010.png)
