### PR TITLE
fix: replace for..of with reverse for

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -499,7 +499,9 @@ function buildTree(
   depPackages: string[],
   packagesByName: GoPackagesByName,
 ) {
-  for (const packageImport of depPackages) {
+  const depPackagesLen = depPackages.length;
+  for (let i = depPackagesLen - 1; i >= 0; i--) {
+    const packageImport = depPackages[i];
     let version = 'unknown';
     if (isBuiltinPackage(packageImport)) {
       // We do not track vulns in Go standard library


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

In order to improve performance and avoid `JavaScript heap out of memory` errors replace `for..of` with the classic `for` loop

#### Any background context you want to provide?

Noticed issue while was investigating 2 similar issues with the go projects: snyk monitor failed for them with the same error and stack traces were identical 

More to read about loops:
https://medium.com/@TravCav/why-reverse-loops-are-faster-a09d65473006
https://medium.com/tech-tajawal/loops-performances-in-node-js-9fbccf2d6aa6
