### PR TITLE
feat: add support dep-graph gomodules and drop deptree

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
+    "@snyk/dep-graph": "1.19.3",
     "@snyk/graphlib": "2.1.9-patch",
     "debug": "^4.1.1",
     "snyk-go-parser": "1.4.1",

--- a/test/fixtures/golist/empty/expected-depgraph.json
+++ b/test/fixtures/golist/empty/expected-depgraph.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": { "name": "gomodules" },
+  "pkgs": [
+    { "id": "empty@0.0.0", "info": { "name": "empty", "version": "0.0.0" } }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [{ "nodeId": "root-node", "pkgId": "empty@0.0.0", "deps": [] }]
+  }
+}

--- a/test/fixtures/golist/empty/expected-tree.json
+++ b/test/fixtures/golist/empty/expected-tree.json
@@ -1,5 +1,0 @@
-{
-    "name": "empty",
-    "version": "0.0.0",
-    "packageFormatVersion": "golang:0.0.1"
-}

--- a/test/fixtures/golist/import/expected-depgraph.json
+++ b/test/fixtures/golist/import/expected-depgraph.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": { "name": "gomodules" },
+  "pkgs": [
+    {
+      "id": "github.com/snyk/go-deps-resolver@0.0.0",
+      "info": { "name": "github.com/snyk/go-deps-resolver", "version": "0.0.0" }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "github.com/snyk/go-deps-resolver@0.0.0",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/test/fixtures/golist/import/expected-tree.json
+++ b/test/fixtures/golist/import/expected-tree.json
@@ -1,5 +1,0 @@
-{
-  "name": "github.com/snyk/go-deps-resolver",
-  "version": "0.0.0",
-  "packageFormatVersion": "golang:0.0.1"
-}

--- a/test/fixtures/gomod-small/expected-gomodules-depgraph.json
+++ b/test/fixtures/gomod-small/expected-gomodules-depgraph.json
@@ -1,0 +1,173 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": { "name": "gomodules" },
+  "pkgs": [
+    {
+      "id": "github.com/antonmedv/expr@0.0.0",
+      "info": { "name": "github.com/antonmedv/expr", "version": "0.0.0" }
+    },
+    {
+      "id": "github.com/sanity-io/litter@1.1.0",
+      "info": { "name": "github.com/sanity-io/litter", "version": "1.1.0" }
+    },
+    {
+      "id": "github.com/rivo/tview@#bd836ef13b4b",
+      "info": { "name": "github.com/rivo/tview", "version": "#bd836ef13b4b" }
+    },
+    {
+      "id": "github.com/rivo/uniseg@#b9f5b9457d44",
+      "info": { "name": "github.com/rivo/uniseg", "version": "#b9f5b9457d44" }
+    },
+    {
+      "id": "github.com/mattn/go-runewidth@0.0.4",
+      "info": { "name": "github.com/mattn/go-runewidth", "version": "0.0.4" }
+    },
+    {
+      "id": "github.com/lucasb-eyer/go-colorful@1.0.2",
+      "info": {
+        "name": "github.com/lucasb-eyer/go-colorful",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "github.com/gdamore/tcell@1.1.2",
+      "info": { "name": "github.com/gdamore/tcell", "version": "1.1.2" }
+    },
+    {
+      "id": "golang.org/x/text/transform@0.3.2",
+      "info": { "name": "golang.org/x/text/transform", "version": "0.3.2" }
+    },
+    {
+      "id": "golang.org/x/text/encoding@0.3.2",
+      "info": { "name": "golang.org/x/text/encoding", "version": "0.3.2" }
+    },
+    {
+      "id": "golang.org/x/text/encoding/internal/identifier@0.3.2",
+      "info": {
+        "name": "golang.org/x/text/encoding/internal/identifier",
+        "version": "0.3.2"
+      }
+    },
+    {
+      "id": "github.com/gdamore/tcell/terminfo@1.1.2",
+      "info": {
+        "name": "github.com/gdamore/tcell/terminfo",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "github.com/gdamore/encoding@1.0.0",
+      "info": { "name": "github.com/gdamore/encoding", "version": "1.0.0" }
+    },
+    {
+      "id": "github.com/antlr/antlr4/runtime/Go/antlr@#edae2a1c9b4b",
+      "info": {
+        "name": "github.com/antlr/antlr4/runtime/Go/antlr",
+        "version": "#edae2a1c9b4b"
+      }
+    },
+    {
+      "id": "golang.org/x/text/width@0.3.2",
+      "info": { "name": "golang.org/x/text/width", "version": "0.3.2" }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "github.com/antonmedv/expr@0.0.0",
+        "deps": [
+          { "nodeId": "github.com/sanity-io/litter" },
+          { "nodeId": "github.com/rivo/tview" },
+          { "nodeId": "github.com/gdamore/tcell" },
+          { "nodeId": "github.com/antlr/antlr4/runtime/Go/antlr" },
+          { "nodeId": "golang.org/x/text/width" }
+        ]
+      },
+      {
+        "nodeId": "github.com/sanity-io/litter",
+        "pkgId": "github.com/sanity-io/litter@1.1.0",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/rivo/tview",
+        "pkgId": "github.com/rivo/tview@#bd836ef13b4b",
+        "deps": [
+          { "nodeId": "github.com/rivo/uniseg" },
+          { "nodeId": "github.com/mattn/go-runewidth" },
+          { "nodeId": "github.com/lucasb-eyer/go-colorful" },
+          { "nodeId": "github.com/gdamore/tcell" }
+        ]
+      },
+      {
+        "nodeId": "github.com/rivo/uniseg",
+        "pkgId": "github.com/rivo/uniseg@#b9f5b9457d44",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/mattn/go-runewidth",
+        "pkgId": "github.com/mattn/go-runewidth@0.0.4",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/lucasb-eyer/go-colorful",
+        "pkgId": "github.com/lucasb-eyer/go-colorful@1.0.2",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/gdamore/tcell",
+        "pkgId": "github.com/gdamore/tcell@1.1.2",
+        "deps": [
+          { "nodeId": "golang.org/x/text/transform" },
+          { "nodeId": "golang.org/x/text/encoding" },
+          { "nodeId": "github.com/mattn/go-runewidth" },
+          { "nodeId": "github.com/lucasb-eyer/go-colorful" },
+          { "nodeId": "github.com/gdamore/tcell/terminfo" },
+          { "nodeId": "github.com/gdamore/encoding" }
+        ]
+      },
+      {
+        "nodeId": "golang.org/x/text/transform",
+        "pkgId": "golang.org/x/text/transform@0.3.2",
+        "deps": []
+      },
+      {
+        "nodeId": "golang.org/x/text/encoding",
+        "pkgId": "golang.org/x/text/encoding@0.3.2",
+        "deps": [
+          { "nodeId": "golang.org/x/text/transform" },
+          { "nodeId": "golang.org/x/text/encoding/internal/identifier" }
+        ]
+      },
+      {
+        "nodeId": "golang.org/x/text/encoding/internal/identifier",
+        "pkgId": "golang.org/x/text/encoding/internal/identifier@0.3.2",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/gdamore/tcell/terminfo",
+        "pkgId": "github.com/gdamore/tcell/terminfo@1.1.2",
+        "deps": []
+      },
+      {
+        "nodeId": "github.com/gdamore/encoding",
+        "pkgId": "github.com/gdamore/encoding@1.0.0",
+        "deps": [
+          { "nodeId": "golang.org/x/text/transform" },
+          { "nodeId": "golang.org/x/text/encoding" }
+        ]
+      },
+      {
+        "nodeId": "github.com/antlr/antlr4/runtime/Go/antlr",
+        "pkgId": "github.com/antlr/antlr4/runtime/Go/antlr@#edae2a1c9b4b",
+        "deps": []
+      },
+      {
+        "nodeId": "golang.org/x/text/width",
+        "pkgId": "golang.org/x/text/width@0.3.2",
+        "deps": [{ "nodeId": "golang.org/x/text/transform" }]
+      }
+    ]
+  }
+}

--- a/test/golist.test.ts
+++ b/test/golist.test.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { buildDepTreeFromImportsAndModules } from '../lib';
+import { buildDepGraphFromImportsAndModules } from '../lib';
 import { goVersion } from './go-version';
 import { test } from 'tap';
 
@@ -9,36 +9,34 @@ const load = (filename: string) =>
 if (goVersion[0] > 1 || goVersion[1] >= 12) {
 
   test('go list parsing', (t) => {
-    t.test('produces dependency tree', async (t) => {
-      // Note that this "tree" has no dependencies, because all the imported packages are either local or builtin.
-      const expectedDepTree = JSON.parse(load('golist/import/expected-tree.json'));
-      const depTreeAndNotice = await buildDepTreeFromImportsAndModules(`${__dirname}/fixtures/golist/import`);
-      t.deepEquals(depTreeAndNotice, expectedDepTree);
+    t.test('produces dependency graph', async (t) => {
+      // Note that this "graph" has no edges/deps, because all the imported packages are either local or builtin.
+      const expectedDepGraph = JSON.parse(load('golist/import/expected-depgraph.json'));
+      const depGraphAndNotice = await buildDepGraphFromImportsAndModules(`${__dirname}/fixtures/golist/import`);
+      t.deepEquals(JSON.stringify(depGraphAndNotice), JSON.stringify(expectedDepGraph));
     });
 
-    t.test('without .go files produces empty tree', async (t) => {
-      const expectedDepTree = JSON.parse(load('golist/empty/expected-tree.json'));
-      const depTreeAndNotice = await buildDepTreeFromImportsAndModules(`${__dirname}/fixtures/golist/empty`);
-      t.deepEquals(depTreeAndNotice, expectedDepTree);
+    t.test('without .go files produces empty graph', async (t) => {
+      const expectedDepGraph = JSON.parse(load('golist/empty/expected-depgraph.json'));
+      const depGraphAndNotice = await buildDepGraphFromImportsAndModules(`${__dirname}/fixtures/golist/empty`);
+     t.deepEquals(JSON.stringify(depGraphAndNotice), JSON.stringify(expectedDepGraph));
     });
 
     t.end();
   });
 
   test('go list parsing with module information', (t) => {
-    t.test('produces dependency tree', async (t) => {
-      const expectedDepTree = JSON.parse(load('gomod-small/expected-tree.json'));
-      const depTreeAndNotice = await buildDepTreeFromImportsAndModules(`${__dirname}/fixtures/gomod-small`);
-      t.deepEquals(depTreeAndNotice, expectedDepTree);
+    t.test('produces dependency graph', async (t) => {
+      const expectedDepGraph = JSON.parse(load('gomod-small/expected-gomodules-depgraph.json'));
+      const depGraphAndNotice = await buildDepGraphFromImportsAndModules(`${__dirname}/fixtures/gomod-small`);
+      t.deepEquals(JSON.stringify(depGraphAndNotice), JSON.stringify(expectedDepGraph));
     });
-
     t.end();
   });
 
 } else {
-
   test('go list parsing with module information', (t) => {
-    t.rejects('throws on older Go versions', buildDepTreeFromImportsAndModules(`${__dirname}/fixtures/gomod-small`));
+    t.rejects('throws on older Go versions', buildDepGraphFromImportsAndModules(`${__dirname}/fixtures/gomod-small`));
     t.end();
   });
 }

--- a/test/inspect.test.ts
+++ b/test/inspect.test.ts
@@ -14,58 +14,61 @@ test('happy inspect', (t) => {
 
   return plugin.inspect('.', 'Gopkg.lock')
     .then((result) => {
-      const plugin = result.plugin;
-      const pkg = result.package;
 
-      t.test('plugin', (t) => {
-        t.ok(plugin, 'plugin');
-        t.equal(plugin.name, 'snyk-go-plugin', 'name');
-        t.match(plugin.runtime, /^go\d+/, 'engine');
-        t.equal(plugin.targetFile, 'Gopkg.lock');
-        t.end();
-      });
+        t.ok(result.plugin, 'result contains a plugin');
+        t.ok(result.package, 'result contains a depTree in package');
 
-      t.test('root pkg', (t) => {
-        t.match(pkg, {
-          name: 'path/to/pkg',
-          version: '',
-          packageFormatVersion: 'golang:0.0.1',
-        }, 'root pkg');
-        t.end();
-      });
+        const plugin = result.plugin;
+        const pkg = result.package;
+  
+        t.test('plugin', (t) => {
+          t.ok(plugin, 'plugin');
+          t.equal(plugin.name, 'snyk-go-plugin', 'name');
+          t.match(plugin.runtime, /^go\d+/, 'engine');
+          t.equal(plugin.targetFile, 'Gopkg.lock');
+          t.end();
+        });
+  
+        t.test('root pkg', (t) => {
+          t.match(pkg, {
+            name: 'path/to/pkg',
+            version: '',
+            packageFormatVersion: 'golang:0.0.1',
+          }, 'root pkg');
+          t.end();
+        });
+  
+        t.test('dependencies', (t) => {
 
-      t.test('dependencies', (t) => {
-        const deps = pkg.dependencies!;
-
-        t.match(deps['gitpub.com/food/salad'], {
-          name: 'gitpub.com/food/salad',
-          version: 'v1.3.7',
-          dependencies: {
-            'gitpub.com/nature/vegetables/tomato': {
-              version: '#b6ffb7d62206806b573348160795ea16a00940a6',
-            },
-            'gitpub.com/nature/vegetables/cucamba': {
-              version: '#b6ffb7d62206806b573348160795ea16a00940a6',
-            },
-          },
-        }, 'salad depends on tomato and cucamba');
-
-        t.match(deps['gitpub.com/meal/dinner'], {
-          version: 'v0.0.7',
-          dependencies: {
-            'gitpub.com/food/salad': {
+            const deps = pkg!.dependencies!;
+            t.match(deps['gitpub.com/food/salad'], {
+              name: 'gitpub.com/food/salad',
               version: 'v1.3.7',
               dependencies: {
                 'gitpub.com/nature/vegetables/tomato': {
                   version: '#b6ffb7d62206806b573348160795ea16a00940a6',
                 },
+                'gitpub.com/nature/vegetables/cucamba': {
+                  version: '#b6ffb7d62206806b573348160795ea16a00940a6',
+                },
               },
-            },
-          },
-        }, 'salad is also a trasitive dependency');
-
-        t.end();
-      });
+            }, 'salad depends on tomato and cucamba');
+    
+            t.match(deps['gitpub.com/meal/dinner'], {
+              version: 'v0.0.7',
+              dependencies: {
+                'gitpub.com/food/salad': {
+                  version: 'v1.3.7',
+                  dependencies: {
+                    'gitpub.com/nature/vegetables/tomato': {
+                      version: '#b6ffb7d62206806b573348160795ea16a00940a6',
+                    },
+                  },
+                },
+              },
+            }, 'salad is also a trasitive dependency');
+            t.end();
+        });
     });
 });
 
@@ -74,6 +77,10 @@ test('pkg with local import', (t) => {
 
   return plugin.inspect('.', 'Gopkg.lock')
     .then((result) => {
+
+      t.ok(result.plugin, 'result contains a plugin');
+      t.ok(result.package, 'result contains a depTree in package');
+      
       const plugin = result.plugin;
       const pkg = result.package;
 
@@ -114,6 +121,10 @@ test('pkg with internal subpkg', (t) => {
 
   return plugin.inspect('.', 'Gopkg.lock')
     .then((result) => {
+
+      t.ok(result.plugin, 'result contains a plugin');
+      t.ok(result.package, 'result contains a depTree in package');
+
       const plugin = result.plugin;
       const pkg = result.package;
 
@@ -154,6 +165,10 @@ test('multi-root project', (t) => {
 
   return plugin.inspect('.', 'Gopkg.lock')
     .then((result) => {
+
+      t.ok(result.plugin, 'result contains a plugin');
+      t.ok(result.package, 'result contains a depTree in package');
+
       const plugin = result.plugin;
       const pkg = result.package;
 
@@ -175,7 +190,8 @@ test('multi-root project', (t) => {
       });
 
       t.test('dependencies', (t) => {
-        const deps = pkg.dependencies!;
+        
+        const deps = pkg!.dependencies!;
 
         t.match(deps['gitpub.com/food/salad'], {
           name: 'gitpub.com/food/salad',
@@ -241,6 +257,10 @@ test('multi-root project without code at root', (t) => {
 
   return plugin.inspect('.', 'Gopkg.lock')
     .then((result) => {
+
+      t.ok(result.plugin, 'result contains a plugin');
+      t.ok(result.package, 'result contains a depTree in package');
+
       const plugin = result.plugin;
       const pkg = result.package;
 
@@ -262,7 +282,7 @@ test('multi-root project without code at root', (t) => {
       });
 
       t.test('dependencies', (t) => {
-        const deps = pkg.dependencies!;
+        const deps = pkg!.dependencies!;
 
         t.match(deps['gitpub.com/food/salad'], {
           name: 'gitpub.com/food/salad',
@@ -342,6 +362,10 @@ test('with external ignores', (t) => {
 
   return plugin.inspect('.', 'Gopkg.lock')
     .then((result) => {
+
+      t.ok(result.plugin, 'result contains a plugin');
+      t.ok(result.package, 'result contains a depTree in package');
+
       const plugin = result.plugin;
       const pkg = result.package;
 
@@ -363,7 +387,7 @@ test('with external ignores', (t) => {
       });
 
       t.test('dependencies', (t) => {
-        const deps = pkg.dependencies!;
+        const deps = pkg!.dependencies!;
 
         t.match(deps['gitpub.com/food/salad'], {
           name: 'gitpub.com/food/salad',
@@ -407,6 +431,10 @@ test('with external ignores (govendor)', (t) => {
 
   return plugin.inspect('.', 'vendor/vendor.json')
     .then((result) => {
+
+      t.ok(result.plugin, 'result contains a plugin');
+      t.ok(result.package, 'result contains a depTree in package');
+
       const plugin = result.plugin;
       const pkg = result.package;
 
@@ -428,7 +456,7 @@ test('with external ignores (govendor)', (t) => {
       });
 
       t.test('dependencies', (t) => {
-        const deps = pkg.dependencies!;
+        const deps = pkg!.dependencies!;
         t.match(deps['gitpub.com/food/salad'], {
           name: 'gitpub.com/food/salad',
           version: 'v1.3.7',
@@ -570,6 +598,9 @@ test('pkg without external deps', (t) => {
 
   return plugin.inspect('.', 'Gopkg.lock')
     .then((result) => {
+
+      t.ok(result.plugin, 'result contains a plugin');
+      t.ok(result.package, 'result contains a depTree in package');
       const plugin = result.plugin;
       const pkg = result.package;
 
@@ -598,6 +629,9 @@ test('happy inspect govendor', (t) => {
 
   return plugin.inspect('.', 'vendor/vendor.json')
     .then((result) => {
+
+      t.ok(result.plugin, 'result contains a plugin');
+      t.ok(result.package, 'result contains a depTree in package');
       const plugin = result.plugin;
       const pkg = result.package;
 
@@ -619,7 +653,7 @@ test('happy inspect govendor', (t) => {
       });
 
       t.test('dependencies', (t) => {
-        const deps = pkg.dependencies!;
+        const deps = pkg!.dependencies!;
 
         t.match(deps['gitpub.com/food/salad'], {
           name: 'gitpub.com/food/salad',
@@ -658,6 +692,10 @@ test('inspect govendor with alternate case', (t) => {
 
   return plugin.inspect('.', 'vendor/vendor.json')
     .then((result) => {
+
+      t.ok(result.plugin, 'result contains a plugin');
+      t.ok(result.package, 'result contains a depTree in package');
+
       const plugin = result.plugin;
       const pkg = result.package;
 
@@ -684,7 +722,7 @@ test('inspect govendor with alternate case', (t) => {
       });
 
       t.test('dependencies', (t) => {
-        const deps = pkg.dependencies!;
+        const deps = pkg!.dependencies!;
 
         t.match(deps['gitpub.com/food/salad'], {
           name: 'gitpub.com/food/salad',
@@ -741,8 +779,12 @@ if (goVersion[0] > 1 || goVersion[1] >= 12) {
     );
 
     let result = await plugin.inspect('.', 'go.mod');
+
+    t.ok(result.plugin, 'result contains a plugin');
+    t.ok(result.dependencyGraph, 'result contains a dependencyGraph');
+
     const pluginInfo = result.plugin;
-    const pkg = result.package;
+    const pkg = result.dependencyGraph;
 
     t.test('plugin', async (t) => {
       t.ok(plugin, 'plugin');
@@ -751,10 +793,9 @@ if (goVersion[0] > 1 || goVersion[1] >= 12) {
       t.equal(pluginInfo.targetFile, 'go.mod');
     });
 
-    t.test('package', async (t) => {
-      const expectedDepTree = JSON.parse(load('gomod-small/expected-tree.json'));
-
-      t.deepEquals(pkg, expectedDepTree);
+    t.test('dependencyGraph', async (t) => {
+     const expectedDepGraph = JSON.parse(load('gomod-small/expected-gomodules-depgraph.json'));
+     t.deepEquals(JSON.stringify(pkg), JSON.stringify(expectedDepGraph));
     });
   });
 
@@ -768,7 +809,7 @@ if (goVersion[0] > 1 || goVersion[1] >= 12) {
 
     let result = await plugin.inspect('.', 'gomod-small/go.mod', { file: 'gomod-small/go.mod' });
     const pluginInfo = result.plugin;
-    const pkg = result.package;
+    const pkg = result.dependencyGraph;
 
     t.test('plugin', async (t) => {
       t.ok(plugin, 'plugin');
@@ -777,11 +818,10 @@ if (goVersion[0] > 1 || goVersion[1] >= 12) {
       t.equal(pluginInfo.targetFile, 'gomod-small/go.mod');
     });
 
-    t.test('package', async (t) => {
-      const expectedDepTree = JSON.parse(load('gomod-small/expected-tree.json'));
-
-      t.deepEquals(pkg, expectedDepTree);
-    });
+    t.test('dependencyGraph', async (t) => {
+      const expectedDepGraph = JSON.parse(load('gomod-small/expected-gomodules-depgraph.json'));
+      t.deepEquals(JSON.stringify(pkg), JSON.stringify(expectedDepGraph));
+     });
   });
 
   test('invalid go.mod', {timeout: 120000}, async (t) => {


### PR DESCRIPTION
#### What does this PR do?
Add support of dep-graph for go-modules and dropping dep-tree

depends of https://github.com/snyk/snyk-go-plugin/pull/73 [depGraph library supports only node v8+] ✅ 