### PR TITLE
fix: update dep-graph to use upstream lodash

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as tmp from 'tmp';
 import debugLib = require('debug');
-import * as graphlib from '@snyk/graphlib';
+import * as graphlib from 'graphlib';
 import { DepGraphBuilder, DepGraph } from '@snyk/dep-graph';
 
 import * as subProcess from './sub-process';

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "@snyk/dep-graph": "1.19.3",
-    "@snyk/graphlib": "2.1.9-patch",
+    "@snyk/dep-graph": "1.19.4",
+    "graphlib": "2.1.8",
     "debug": "^4.1.1",
     "snyk-go-parser": "1.4.1",
     "tmp": "0.2.1",


### PR DESCRIPTION
Updating dep-graph to prevent including our lodash fork.

HAMMER-99