### PR TITLE
chore: Enable releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,6 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/node:<< parameters.node_version >>
-    environment:
-      NODE_ENV: "production"
     resource_class: small
     steps:
       - checkout


### PR DESCRIPTION
#### What does this PR do?

- Allow releases to actually work
- `tsc` was not available during npm "publish" due to `NODE_ENV`
- This is a library, not a service