### PR TITLE
chore: fix release step in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ workflows:
       - release:
           name: Release
           context: nodejs-app-release
-          node_version: "10"
+          node_version: "14"
           requires:
             - test-unix
             - test-windows


### PR DESCRIPTION
Fix circle ci release step