### PR TITLE
fix: remove error for vscode terminal

### DIFF
--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,13 +1,6 @@
 import * as childProcess from 'child_process';
 
 export function execute(command: string, args: string[], options?: { cwd?: string, env?: any }): Promise<string> {
-
-  if (process.env.TERM_PROGRAM === 'vscode') {
-    throw new Error('running go subprocesses in VS Code seems to be broken!');
-    // Namely, it seems that no data is collected from stdout/stderr streams.
-    // Even just running `go version > 1.txt` in the terminal produces an empty file.
-  }
-
   const spawnOptions: childProcess.SpawnOptions = {shell: true};
   if (options?.cwd) {
     spawnOptions.cwd = options.cwd;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Removes an error that prevents this tool from running within the VSCode integrated terminal. This error was added three years ago and it no longer appears to be an issue.

#### Where should the reviewer start?

`lib/sub-process.ts`

#### How should this be manually tested?

1. Install this into a local copy of Snyk CLI
2. Open up a Go project with VSCode
3. Open up the integrated terminal within that window
4. Run `snyk test` with your modified Snyk CLI

#### Screenshots

Screenshot of this modification running in the VSCode integrated terminal:

![Screen Shot 2022-05-26 at 9 08 55 AM](https://user-images.githubusercontent.com/99991410/170493953-cd8a193f-54bd-4dfa-96b9-074eaaacfdd7.png)
