### PR TITLE
fix: bind govendor tests to specific version range

### DIFF
--- a/test/system/system.test.ts
+++ b/test/system/system.test.ts
@@ -23,29 +23,29 @@ if (goVersion[0] > 1 || goVersion[1] < 16) {
       'expected-list.json'
     );
   });
-}
 
-test('install govendor', {timeout: 120 * 1000}, function () {
-  chdirToPkg([]);
-  return getGovendor();
-});
-
-test('prometheus 1.8', (t) => {
-  chdirToPkg(['github.com', 'prometheus']);
-  return clonePkg(
-    'https://github.com/prometheus/prometheus',
-    'v1.8.0',
-    'prometheus'
-  ).then(function () {
-    const expectedPromDeps = isRunningOnWindows ? 'prometheus-ms-expected-list.json' : 'prometheus-unix-expected-list.json'
-    return testPkg(t,
-      ['github.com', 'prometheus', 'prometheus', 'cmd', 'prometheus'],
-      ['..', '..', 'vendor', 'vendor.json'].join(path.sep),
-      ['..', '..', '..',
-        expectedPromDeps].join(path.sep)
-    );
+  test('install govendor', {timeout: 120 * 1000}, function () {
+    chdirToPkg([]);
+    return getGovendor();
   });
-});
+
+  test('prometheus 1.8', (t) => {
+    chdirToPkg(['github.com', 'prometheus']);
+    return clonePkg(
+        'https://github.com/prometheus/prometheus',
+        'v1.8.0',
+        'prometheus'
+    ).then(function () {
+      const expectedPromDeps = isRunningOnWindows ? 'prometheus-ms-expected-list.json' : 'prometheus-unix-expected-list.json'
+      return testPkg(t,
+          ['github.com', 'prometheus', 'prometheus', 'cmd', 'prometheus'],
+          ['..', '..', 'vendor', 'vendor.json'].join(path.sep),
+          ['..', '..', '..',
+            expectedPromDeps].join(path.sep)
+      );
+    });
+  });
+}
 
 function testPkg(t, pkgPathArray, targetFile, expectedPkgsListFile) {
   chdirToPkg(pkgPathArray);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Adjust the tests related to `govendor` to use only versions of `golang` which are lower than `1.16`.
Soon we will start the deprecation of `govendor` support from our product.