### PR TITLE
fix: default initialization for env

### DIFF
--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -4,7 +4,7 @@ export function execute(command: string,
                         args: string[],
                         options?: { cwd?: string, env?: any },
                         shell: boolean = false): Promise<string> {
-  const spawnOptions: childProcess.SpawnOptions = { shell };
+  const spawnOptions: childProcess.SpawnOptions = { shell, env: process.env };
   if (options?.cwd) {
     spawnOptions.cwd = options.cwd;
   }


### PR DESCRIPTION
Fix missing intialization of 'spawnOptions.env'