### PR TITLE
fix: upgrade node version in release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ workflows:
       - release:
           name: Release
           context: nodejs-app-release
-          node_version: "14"
+          node_version: "18"
           requires:
             - test-unix
             - test-windows


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Update the node runtime version from 14 to 18 for the release step, which was required by a dependency.
