### PR TITLE
feat: bump go parser v1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@snyk/graphlib": "2.1.9-patch.3",
     "debug": "^4.1.1",
     "lookpath": "^1.2.2",
-    "snyk-go-parser": "1.4.1",
+    "snyk-go-parser": "1.13.0",
     "tmp": "0.2.1",
     "tslib": "^1.10.0"
   },


### PR DESCRIPTION
This bumps the snyk-go-parser version to 1.13.0 - for more info see here https://github.com/snyk/snyk-go-parser/pull/45