### PR TITLE
feat: add golang purls to PkgInfo [OSM-607]

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "@snyk/dep-graph": "^1.23.1",
+    "@snyk/dep-graph": "^2.7.2",
     "@snyk/graphlib": "2.1.9-patch.3",
     "debug": "^4.1.1",
     "lookpath": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "@snyk/dep-graph": "^2.7.2",
+    "@snyk/dep-graph": "^2.7.4",
     "@snyk/graphlib": "2.1.9-patch.3",
     "debug": "^4.1.1",
     "lookpath": "^1.2.2",
+    "packageurl-js": "^1.0.2",
     "snyk-go-parser": "1.13.0",
     "tmp": "0.2.1",
     "tslib": "^1.10.0"

--- a/test/fixtures/golist/empty/expected-depgraph.json
+++ b/test/fixtures/golist/empty/expected-depgraph.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.2.0",
+  "schemaVersion": "1.3.0",
   "pkgManager": { "name": "gomodules" },
   "pkgs": [
     { "id": "empty@0.0.0", "info": { "name": "empty", "version": "0.0.0" } }

--- a/test/fixtures/golist/import/expected-depgraph.json
+++ b/test/fixtures/golist/import/expected-depgraph.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.2.0",
+  "schemaVersion": "1.3.0",
   "pkgManager": { "name": "gomodules" },
   "pkgs": [
     {

--- a/test/fixtures/gomod-replace/expected-depgraph.json
+++ b/test/fixtures/gomod-replace/expected-depgraph.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.2.0",
+  "schemaVersion": "1.3.0",
   "pkgManager": {
     "name": "gomodules"
   },

--- a/test/fixtures/gomod-replace/expected-depgraph.json
+++ b/test/fixtures/gomod-replace/expected-depgraph.json
@@ -15,28 +15,32 @@
       "id": "github.com/stretchr/testify/assert@1.6.1",
       "info": {
         "name": "github.com/stretchr/testify/assert",
-        "version": "1.6.1"
+        "version": "1.6.1",
+        "purl": "pkg:golang/github.com/stretchr/testify@v1.6.1#assert"
       }
     },
     {
       "id": "gopkg.in/yaml.v3@#9f266ea9e77c",
       "info": {
         "name": "gopkg.in/yaml.v3",
-        "version": "#9f266ea9e77c"
+        "version": "#9f266ea9e77c",
+        "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c"
       }
     },
     {
       "id": "github.com/pmezard/go-difflib/difflib@1.0.0",
       "info": {
         "name": "github.com/pmezard/go-difflib/difflib",
-        "version": "1.0.0"
+        "version": "1.0.0",
+        "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0#difflib"
       }
     },
     {
       "id": "github.com/davecgh/go-spew/spew@1.1.0",
       "info": {
         "name": "github.com/davecgh/go-spew/spew",
-        "version": "1.1.0"
+        "version": "1.1.0",
+        "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.0#spew"
       }
     }
   ],

--- a/test/fixtures/gomod-small/expected-gomodules-depgraph.json
+++ b/test/fixtures/gomod-small/expected-gomodules-depgraph.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.2.0",
+  "schemaVersion": "1.3.0",
   "pkgManager": {
     "name": "gomodules"
   },

--- a/test/fixtures/gomod-small/expected-gomodules-depgraph.json
+++ b/test/fixtures/gomod-small/expected-gomodules-depgraph.json
@@ -15,91 +15,104 @@
       "id": "github.com/sanity-io/litter@1.1.0",
       "info": {
         "name": "github.com/sanity-io/litter",
-        "version": "1.1.0"
+        "version": "1.1.0",
+        "purl": "pkg:golang/github.com/sanity-io/litter@v1.1.0"
       }
     },
     {
       "id": "github.com/rivo/tview@#bd836ef13b4b",
       "info": {
         "name": "github.com/rivo/tview",
-        "version": "#bd836ef13b4b"
+        "version": "#bd836ef13b4b",
+        "purl": "pkg:golang/github.com/rivo/tview@v0.0.0-20190515161233-bd836ef13b4b"
       }
     },
     {
       "id": "github.com/rivo/uniseg@#b9f5b9457d44",
       "info": {
         "name": "github.com/rivo/uniseg",
-        "version": "#b9f5b9457d44"
+        "version": "#b9f5b9457d44",
+        "purl": "pkg:golang/github.com/rivo/uniseg@v0.0.0-20190513083848-b9f5b9457d44"
       }
     },
     {
       "id": "github.com/mattn/go-runewidth@0.0.4",
       "info": {
         "name": "github.com/mattn/go-runewidth",
-        "version": "0.0.4"
+        "version": "0.0.4",
+        "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.4"
       }
     },
     {
       "id": "github.com/lucasb-eyer/go-colorful@1.0.2",
       "info": {
         "name": "github.com/lucasb-eyer/go-colorful",
-        "version": "1.0.2"
+        "version": "1.0.2",
+        "purl": "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.0.2"
       }
     },
     {
       "id": "github.com/gdamore/tcell@1.1.2",
       "info": {
         "name": "github.com/gdamore/tcell",
-        "version": "1.1.2"
+        "version": "1.1.2",
+        "purl": "pkg:golang/github.com/gdamore/tcell@v1.1.2"
       }
     },
     {
       "id": "golang.org/x/text/transform@0.3.2",
       "info": {
         "name": "golang.org/x/text/transform",
-        "version": "0.3.2"
+        "version": "0.3.2",
+        "purl": "pkg:golang/golang.org/x/text@v0.3.2#transform"
       }
     },
     {
       "id": "golang.org/x/text/encoding@0.3.2",
       "info": {
         "name": "golang.org/x/text/encoding",
-        "version": "0.3.2"
+        "version": "0.3.2",
+        "purl": "pkg:golang/golang.org/x/text@v0.3.2#encoding"
       }
     },
     {
       "id": "golang.org/x/text/encoding/internal/identifier@0.3.2",
       "info": {
         "name": "golang.org/x/text/encoding/internal/identifier",
-        "version": "0.3.2"
+        "version": "0.3.2",
+        "purl": "pkg:golang/golang.org/x/text@v0.3.2#encoding/internal/identifier"
       }
     },
     {
       "id": "github.com/gdamore/tcell/terminfo@1.1.2",
       "info": {
         "name": "github.com/gdamore/tcell/terminfo",
-        "version": "1.1.2"
+        "version": "1.1.2",
+        "purl": "pkg:golang/github.com/gdamore/tcell@v1.1.2#terminfo"
       }
     },
     {
       "id": "github.com/gdamore/encoding@1.0.0",
       "info": {
         "name": "github.com/gdamore/encoding",
-        "version": "1.0.0"
+        "version": "1.0.0",
+        "purl": "pkg:golang/github.com/gdamore/encoding@v1.0.0"
       }
     },
     {
       "id": "github.com/antlr/antlr4/runtime/Go/antlr@#edae2a1c9b4b",
       "info": {
         "name": "github.com/antlr/antlr4/runtime/Go/antlr",
-        "version": "#edae2a1c9b4b"
+        "version": "#edae2a1c9b4b",
+        "purl": "pkg:golang/github.com/antlr/antlr4@v0.0.0-20190518164840-edae2a1c9b4b#runtime/Go/antlr"
       }
     },
     {
       "id": "golang.org/x/text/width@0.3.2",
       "info": {
         "name": "golang.org/x/text/width",
-        "version": "0.3.2"
+        "version": "0.3.2",
+        "purl": "pkg:golang/golang.org/x/text@v0.3.2#width"
       }
     }
   ],


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

This introduces the generation of PackageURLs when a `golang` dependency graph is being constructed. This will enable us to output valid `golang` purls during the export of a project’s SBOM, or the generation of a document on the client side.