### PR TITLE
feat: enable PackageURLs through configuration

### DIFF
--- a/lib/dep-graph.ts
+++ b/lib/dep-graph.ts
@@ -6,7 +6,7 @@ import { GoModule, GoPackage, Options } from './types';
 import { CustomError } from './errors/custom-error';
 import { parseVersion, toSnykVersion } from './version';
 import { runGo } from './sub-process';
-import { createGoPurl, shouldIncludePackageUrls } from './package-url';
+import { createGoPurl } from './package-url';
 
 export async function getDepGraph(
   root: string,
@@ -23,7 +23,7 @@ export async function getDepGraph(
     ? await resolveStdlibVersion(root, targetFile)
     : 'unknown';
 
-  const includePackageUrls = shouldIncludePackageUrls(options);
+  const includePackageUrls = configuration?.includePackageUrls ?? false;
 
   return buildDepGraphFromImportsAndModules(root, targetFile, {
     stdlibVersion,

--- a/lib/package-url.ts
+++ b/lib/package-url.ts
@@ -1,12 +1,6 @@
 import { PackageURL } from 'packageurl-js';
 
-import { Options } from './types';
-
 const PURL_TYPE_GOLANG = 'golang';
-
-export function shouldIncludePackageUrls(options: Options): boolean {
-  return !!options['print-graph'];
-}
 
 interface GoModule {
   Version: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -24,8 +24,8 @@ export interface Options {
   args?: string[];
   configuration?: {
     includeGoStandardLibraryDeps?: boolean;
+    includePackageUrls?: boolean;
   };
-  'print-graph'?: boolean;
 }
 
 export interface DepGraphResult {

--- a/test/purls.test.ts
+++ b/test/purls.test.ts
@@ -66,4 +66,16 @@ test('dependency graph with package urls', async (t) => {
     );
     t.equal(JSON.stringify(depGraph), JSON.stringify(expectedDepGraph));
   });
+
+  t.test('produces a dependency graph without package urls', async (t) => {
+    const expectedDepGraph = JSON.parse(
+      load('gomod-small/expected-gomodules-depgraph.json'),
+    );
+    const depGraph = await buildDepGraphFromImportsAndModules(
+      `${__dirname}/fixtures/gomod-small`,
+      undefined,
+      { includePackageUrls: false },
+    );
+    t.equal(JSON.stringify(depGraph), JSON.stringify(expectedDepGraph));
+  });
 });


### PR DESCRIPTION
#### What does this PR do?

This removes the dependency on `options['print-graph']` for PackageURLs within the dep-graph, and instead adds this as a flag into `options.configuration`, in line with `includeGoStandardLibraryDeps`.