### PR TITLE
feat!: generate PackageURLs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,26 @@ Snyk helps you find, fix and monitor for known vulnerabilities in your dependenc
 ## Snyk Golang CLI Plugin
 
 This plugin provides dependency metadata for Golang projects that use `dep` (and have a `Gopkg.lock` file), or `govendor` (and have a `vendor/vendor.json` file).
+
+## Breaking changes in v2.x
+
+When upgrading from v1 to v2 of this plugin, note that PackageURL information will be present by default when invoking the `inspect()` function.
+
+```diff
+  {
+    "name": "golang.org/x/exp/slices"
+    "version": "#2e198f4a06a1"
++   "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20230522175609-2e198f4a06a1#slices"
+  }
+```
+
+To disable this behaviour, it can be turned off through the options passed to the function:
+
+```diff
+  const result = await inspect(
+    process.cwd(),
+    "go.mod",
+-   {},
++   { configuration: { includePackageUrls: false } },
+  )
+```

--- a/lib/dep-graph.ts
+++ b/lib/dep-graph.ts
@@ -23,7 +23,7 @@ export async function getDepGraph(
     ? await resolveStdlibVersion(root, targetFile)
     : 'unknown';
 
-  const includePackageUrls = configuration?.includePackageUrls ?? false;
+  const includePackageUrls = configuration?.includePackageUrls ?? true;
 
   return buildDepGraphFromImportsAndModules(root, targetFile, {
     stdlibVersion,

--- a/test/fixtures/gomod-small/expected-gomodules-depgraph-no-purls.json
+++ b/test/fixtures/gomod-small/expected-gomodules-depgraph-no-purls.json
@@ -1,117 +1,105 @@
 {
   "schemaVersion": "1.3.0",
-  "pkgManager": { "name": "gomodules" },
+  "pkgManager": {
+    "name": "gomodules"
+  },
   "pkgs": [
     {
       "id": "github.com/antonmedv/expr@0.0.0",
       "info": {
         "name": "github.com/antonmedv/expr",
-        "version": "0.0.0",
-        "purl": "pkg:golang/github.com/antonmedv/expr@0.0.0"
+        "version": "0.0.0"
       }
     },
     {
       "id": "github.com/sanity-io/litter@1.1.0",
       "info": {
         "name": "github.com/sanity-io/litter",
-        "version": "1.1.0",
-        "purl": "pkg:golang/github.com/sanity-io/litter@v1.1.0"
+        "version": "1.1.0"
       }
     },
     {
       "id": "github.com/rivo/tview@#bd836ef13b4b",
       "info": {
         "name": "github.com/rivo/tview",
-        "version": "#bd836ef13b4b",
-        "purl": "pkg:golang/github.com/rivo/tview@v0.0.0-20190515161233-bd836ef13b4b"
+        "version": "#bd836ef13b4b"
       }
     },
     {
       "id": "github.com/rivo/uniseg@#b9f5b9457d44",
       "info": {
         "name": "github.com/rivo/uniseg",
-        "version": "#b9f5b9457d44",
-        "purl": "pkg:golang/github.com/rivo/uniseg@v0.0.0-20190513083848-b9f5b9457d44"
+        "version": "#b9f5b9457d44"
       }
     },
     {
       "id": "github.com/mattn/go-runewidth@0.0.4",
       "info": {
         "name": "github.com/mattn/go-runewidth",
-        "version": "0.0.4",
-        "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.4"
+        "version": "0.0.4"
       }
     },
     {
       "id": "github.com/lucasb-eyer/go-colorful@1.0.2",
       "info": {
         "name": "github.com/lucasb-eyer/go-colorful",
-        "version": "1.0.2",
-        "purl": "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.0.2"
+        "version": "1.0.2"
       }
     },
     {
       "id": "github.com/gdamore/tcell@1.1.2",
       "info": {
         "name": "github.com/gdamore/tcell",
-        "version": "1.1.2",
-        "purl": "pkg:golang/github.com/gdamore/tcell@v1.1.2"
+        "version": "1.1.2"
       }
     },
     {
       "id": "golang.org/x/text/transform@0.3.2",
       "info": {
         "name": "golang.org/x/text/transform",
-        "version": "0.3.2",
-        "purl": "pkg:golang/golang.org/x/text@v0.3.2#transform"
+        "version": "0.3.2"
       }
     },
     {
       "id": "golang.org/x/text/encoding@0.3.2",
       "info": {
         "name": "golang.org/x/text/encoding",
-        "version": "0.3.2",
-        "purl": "pkg:golang/golang.org/x/text@v0.3.2#encoding"
+        "version": "0.3.2"
       }
     },
     {
       "id": "golang.org/x/text/encoding/internal/identifier@0.3.2",
       "info": {
         "name": "golang.org/x/text/encoding/internal/identifier",
-        "version": "0.3.2",
-        "purl": "pkg:golang/golang.org/x/text@v0.3.2#encoding/internal/identifier"
+        "version": "0.3.2"
       }
     },
     {
       "id": "github.com/gdamore/tcell/terminfo@1.1.2",
       "info": {
         "name": "github.com/gdamore/tcell/terminfo",
-        "version": "1.1.2",
-        "purl": "pkg:golang/github.com/gdamore/tcell@v1.1.2#terminfo"
+        "version": "1.1.2"
       }
     },
     {
       "id": "github.com/gdamore/encoding@1.0.0",
       "info": {
         "name": "github.com/gdamore/encoding",
-        "version": "1.0.0",
-        "purl": "pkg:golang/github.com/gdamore/encoding@v1.0.0"
+        "version": "1.0.0"
       }
     },
     {
       "id": "github.com/antlr/antlr4/runtime/Go/antlr@#edae2a1c9b4b",
       "info": {
         "name": "github.com/antlr/antlr4/runtime/Go/antlr",
-        "version": "#edae2a1c9b4b",
-        "purl": "pkg:golang/github.com/antlr/antlr4@v0.0.0-20190518164840-edae2a1c9b4b#runtime/Go/antlr"
+        "version": "#edae2a1c9b4b"
       }
     },
     {
       "id": "golang.org/x/text/width@0.3.2",
       "info": {
         "name": "golang.org/x/text/width",
-        "version": "0.3.2",
-        "purl": "pkg:golang/golang.org/x/text@v0.3.2#width"
+        "version": "0.3.2"
       }
     }
   ],
@@ -122,11 +110,21 @@
         "nodeId": "root-node",
         "pkgId": "github.com/antonmedv/expr@0.0.0",
         "deps": [
-          { "nodeId": "github.com/sanity-io/litter" },
-          { "nodeId": "github.com/rivo/tview" },
-          { "nodeId": "github.com/gdamore/tcell" },
-          { "nodeId": "github.com/antlr/antlr4/runtime/Go/antlr" },
-          { "nodeId": "golang.org/x/text/width" }
+          {
+            "nodeId": "github.com/sanity-io/litter"
+          },
+          {
+            "nodeId": "github.com/rivo/tview"
+          },
+          {
+            "nodeId": "github.com/gdamore/tcell"
+          },
+          {
+            "nodeId": "github.com/antlr/antlr4/runtime/Go/antlr"
+          },
+          {
+            "nodeId": "golang.org/x/text/width"
+          }
         ]
       },
       {
@@ -138,10 +136,18 @@
         "nodeId": "github.com/rivo/tview",
         "pkgId": "github.com/rivo/tview@#bd836ef13b4b",
         "deps": [
-          { "nodeId": "github.com/rivo/uniseg" },
-          { "nodeId": "github.com/mattn/go-runewidth" },
-          { "nodeId": "github.com/lucasb-eyer/go-colorful" },
-          { "nodeId": "github.com/gdamore/tcell" }
+          {
+            "nodeId": "github.com/rivo/uniseg"
+          },
+          {
+            "nodeId": "github.com/mattn/go-runewidth"
+          },
+          {
+            "nodeId": "github.com/lucasb-eyer/go-colorful"
+          },
+          {
+            "nodeId": "github.com/gdamore/tcell"
+          }
         ]
       },
       {
@@ -163,14 +169,30 @@
         "nodeId": "github.com/gdamore/tcell",
         "pkgId": "github.com/gdamore/tcell@1.1.2",
         "deps": [
-          { "nodeId": "golang.org/x/text/transform" },
-          { "nodeId": "golang.org/x/text/encoding" },
-          { "nodeId": "github.com/mattn/go-runewidth:pruned" },
-          { "nodeId": "github.com/lucasb-eyer/go-colorful:pruned" },
-          { "nodeId": "github.com/gdamore/tcell/terminfo" },
-          { "nodeId": "github.com/gdamore/encoding" },
-          { "nodeId": "github.com/mattn/go-runewidth" },
-          { "nodeId": "github.com/lucasb-eyer/go-colorful" }
+          {
+            "nodeId": "golang.org/x/text/transform"
+          },
+          {
+            "nodeId": "golang.org/x/text/encoding"
+          },
+          {
+            "nodeId": "github.com/mattn/go-runewidth:pruned"
+          },
+          {
+            "nodeId": "github.com/lucasb-eyer/go-colorful:pruned"
+          },
+          {
+            "nodeId": "github.com/gdamore/tcell/terminfo"
+          },
+          {
+            "nodeId": "github.com/gdamore/encoding"
+          },
+          {
+            "nodeId": "github.com/mattn/go-runewidth"
+          },
+          {
+            "nodeId": "github.com/lucasb-eyer/go-colorful"
+          }
         ]
       },
       {
@@ -182,15 +204,23 @@
         "nodeId": "golang.org/x/text/encoding",
         "pkgId": "golang.org/x/text/encoding@0.3.2",
         "deps": [
-          { "nodeId": "golang.org/x/text/transform:pruned" },
-          { "nodeId": "golang.org/x/text/encoding/internal/identifier" }
+          {
+            "nodeId": "golang.org/x/text/transform:pruned"
+          },
+          {
+            "nodeId": "golang.org/x/text/encoding/internal/identifier"
+          }
         ]
       },
       {
         "nodeId": "golang.org/x/text/transform:pruned",
         "pkgId": "golang.org/x/text/transform@0.3.2",
         "deps": [],
-        "info": { "labels": { "pruned": "true" } }
+        "info": {
+          "labels": {
+            "pruned": "true"
+          }
+        }
       },
       {
         "nodeId": "golang.org/x/text/encoding/internal/identifier",
@@ -201,13 +231,21 @@
         "nodeId": "github.com/mattn/go-runewidth:pruned",
         "pkgId": "github.com/mattn/go-runewidth@0.0.4",
         "deps": [],
-        "info": { "labels": { "pruned": "true" } }
+        "info": {
+          "labels": {
+            "pruned": "true"
+          }
+        }
       },
       {
         "nodeId": "github.com/lucasb-eyer/go-colorful:pruned",
         "pkgId": "github.com/lucasb-eyer/go-colorful@1.0.2",
         "deps": [],
-        "info": { "labels": { "pruned": "true" } }
+        "info": {
+          "labels": {
+            "pruned": "true"
+          }
+        }
       },
       {
         "nodeId": "github.com/gdamore/tcell/terminfo",
@@ -218,15 +256,23 @@
         "nodeId": "github.com/gdamore/encoding",
         "pkgId": "github.com/gdamore/encoding@1.0.0",
         "deps": [
-          { "nodeId": "golang.org/x/text/transform:pruned" },
-          { "nodeId": "golang.org/x/text/encoding:pruned" }
+          {
+            "nodeId": "golang.org/x/text/transform:pruned"
+          },
+          {
+            "nodeId": "golang.org/x/text/encoding:pruned"
+          }
         ]
       },
       {
         "nodeId": "golang.org/x/text/encoding:pruned",
         "pkgId": "golang.org/x/text/encoding@0.3.2",
         "deps": [],
-        "info": { "labels": { "pruned": "true" } }
+        "info": {
+          "labels": {
+            "pruned": "true"
+          }
+        }
       },
       {
         "nodeId": "github.com/antlr/antlr4/runtime/Go/antlr",
@@ -236,7 +282,11 @@
       {
         "nodeId": "golang.org/x/text/width",
         "pkgId": "golang.org/x/text/width@0.3.2",
-        "deps": [{ "nodeId": "golang.org/x/text/transform" }]
+        "deps": [
+          {
+            "nodeId": "golang.org/x/text/transform"
+          }
+        ]
       }
     ]
   }

--- a/test/fixtures/gomod-small/expected-gomodules-depgraph.json
+++ b/test/fixtures/gomod-small/expected-gomodules-depgraph.json
@@ -1,105 +1,117 @@
 {
   "schemaVersion": "1.3.0",
-  "pkgManager": {
-    "name": "gomodules"
-  },
+  "pkgManager": { "name": "gomodules" },
   "pkgs": [
     {
       "id": "github.com/antonmedv/expr@0.0.0",
       "info": {
         "name": "github.com/antonmedv/expr",
-        "version": "0.0.0"
+        "version": "0.0.0",
+        "purl": "pkg:golang/github.com/antonmedv/expr@0.0.0"
       }
     },
     {
       "id": "github.com/sanity-io/litter@1.1.0",
       "info": {
         "name": "github.com/sanity-io/litter",
-        "version": "1.1.0"
+        "version": "1.1.0",
+        "purl": "pkg:golang/github.com/sanity-io/litter@v1.1.0"
       }
     },
     {
       "id": "github.com/rivo/tview@#bd836ef13b4b",
       "info": {
         "name": "github.com/rivo/tview",
-        "version": "#bd836ef13b4b"
+        "version": "#bd836ef13b4b",
+        "purl": "pkg:golang/github.com/rivo/tview@v0.0.0-20190515161233-bd836ef13b4b"
       }
     },
     {
       "id": "github.com/rivo/uniseg@#b9f5b9457d44",
       "info": {
         "name": "github.com/rivo/uniseg",
-        "version": "#b9f5b9457d44"
+        "version": "#b9f5b9457d44",
+        "purl": "pkg:golang/github.com/rivo/uniseg@v0.0.0-20190513083848-b9f5b9457d44"
       }
     },
     {
       "id": "github.com/mattn/go-runewidth@0.0.4",
       "info": {
         "name": "github.com/mattn/go-runewidth",
-        "version": "0.0.4"
+        "version": "0.0.4",
+        "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.4"
       }
     },
     {
       "id": "github.com/lucasb-eyer/go-colorful@1.0.2",
       "info": {
         "name": "github.com/lucasb-eyer/go-colorful",
-        "version": "1.0.2"
+        "version": "1.0.2",
+        "purl": "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.0.2"
       }
     },
     {
       "id": "github.com/gdamore/tcell@1.1.2",
       "info": {
         "name": "github.com/gdamore/tcell",
-        "version": "1.1.2"
+        "version": "1.1.2",
+        "purl": "pkg:golang/github.com/gdamore/tcell@v1.1.2"
       }
     },
     {
       "id": "golang.org/x/text/transform@0.3.2",
       "info": {
         "name": "golang.org/x/text/transform",
-        "version": "0.3.2"
+        "version": "0.3.2",
+        "purl": "pkg:golang/golang.org/x/text@v0.3.2#transform"
       }
     },
     {
       "id": "golang.org/x/text/encoding@0.3.2",
       "info": {
         "name": "golang.org/x/text/encoding",
-        "version": "0.3.2"
+        "version": "0.3.2",
+        "purl": "pkg:golang/golang.org/x/text@v0.3.2#encoding"
       }
     },
     {
       "id": "golang.org/x/text/encoding/internal/identifier@0.3.2",
       "info": {
         "name": "golang.org/x/text/encoding/internal/identifier",
-        "version": "0.3.2"
+        "version": "0.3.2",
+        "purl": "pkg:golang/golang.org/x/text@v0.3.2#encoding/internal/identifier"
       }
     },
     {
       "id": "github.com/gdamore/tcell/terminfo@1.1.2",
       "info": {
         "name": "github.com/gdamore/tcell/terminfo",
-        "version": "1.1.2"
+        "version": "1.1.2",
+        "purl": "pkg:golang/github.com/gdamore/tcell@v1.1.2#terminfo"
       }
     },
     {
       "id": "github.com/gdamore/encoding@1.0.0",
       "info": {
         "name": "github.com/gdamore/encoding",
-        "version": "1.0.0"
+        "version": "1.0.0",
+        "purl": "pkg:golang/github.com/gdamore/encoding@v1.0.0"
       }
     },
     {
       "id": "github.com/antlr/antlr4/runtime/Go/antlr@#edae2a1c9b4b",
       "info": {
         "name": "github.com/antlr/antlr4/runtime/Go/antlr",
-        "version": "#edae2a1c9b4b"
+        "version": "#edae2a1c9b4b",
+        "purl": "pkg:golang/github.com/antlr/antlr4@v0.0.0-20190518164840-edae2a1c9b4b#runtime/Go/antlr"
       }
     },
     {
       "id": "golang.org/x/text/width@0.3.2",
       "info": {
         "name": "golang.org/x/text/width",
-        "version": "0.3.2"
+        "version": "0.3.2",
+        "purl": "pkg:golang/golang.org/x/text@v0.3.2#width"
       }
     }
   ],
@@ -110,21 +122,11 @@
         "nodeId": "root-node",
         "pkgId": "github.com/antonmedv/expr@0.0.0",
         "deps": [
-          {
-            "nodeId": "github.com/sanity-io/litter"
-          },
-          {
-            "nodeId": "github.com/rivo/tview"
-          },
-          {
-            "nodeId": "github.com/gdamore/tcell"
-          },
-          {
-            "nodeId": "github.com/antlr/antlr4/runtime/Go/antlr"
-          },
-          {
-            "nodeId": "golang.org/x/text/width"
-          }
+          { "nodeId": "github.com/sanity-io/litter" },
+          { "nodeId": "github.com/rivo/tview" },
+          { "nodeId": "github.com/gdamore/tcell" },
+          { "nodeId": "github.com/antlr/antlr4/runtime/Go/antlr" },
+          { "nodeId": "golang.org/x/text/width" }
         ]
       },
       {
@@ -136,18 +138,10 @@
         "nodeId": "github.com/rivo/tview",
         "pkgId": "github.com/rivo/tview@#bd836ef13b4b",
         "deps": [
-          {
-            "nodeId": "github.com/rivo/uniseg"
-          },
-          {
-            "nodeId": "github.com/mattn/go-runewidth"
-          },
-          {
-            "nodeId": "github.com/lucasb-eyer/go-colorful"
-          },
-          {
-            "nodeId": "github.com/gdamore/tcell"
-          }
+          { "nodeId": "github.com/rivo/uniseg" },
+          { "nodeId": "github.com/mattn/go-runewidth" },
+          { "nodeId": "github.com/lucasb-eyer/go-colorful" },
+          { "nodeId": "github.com/gdamore/tcell" }
         ]
       },
       {
@@ -169,30 +163,14 @@
         "nodeId": "github.com/gdamore/tcell",
         "pkgId": "github.com/gdamore/tcell@1.1.2",
         "deps": [
-          {
-            "nodeId": "golang.org/x/text/transform"
-          },
-          {
-            "nodeId": "golang.org/x/text/encoding"
-          },
-          {
-            "nodeId": "github.com/mattn/go-runewidth:pruned"
-          },
-          {
-            "nodeId": "github.com/lucasb-eyer/go-colorful:pruned"
-          },
-          {
-            "nodeId": "github.com/gdamore/tcell/terminfo"
-          },
-          {
-            "nodeId": "github.com/gdamore/encoding"
-          },
-          {
-            "nodeId": "github.com/mattn/go-runewidth"
-          },
-          {
-            "nodeId": "github.com/lucasb-eyer/go-colorful"
-          }
+          { "nodeId": "golang.org/x/text/transform" },
+          { "nodeId": "golang.org/x/text/encoding" },
+          { "nodeId": "github.com/mattn/go-runewidth:pruned" },
+          { "nodeId": "github.com/lucasb-eyer/go-colorful:pruned" },
+          { "nodeId": "github.com/gdamore/tcell/terminfo" },
+          { "nodeId": "github.com/gdamore/encoding" },
+          { "nodeId": "github.com/mattn/go-runewidth" },
+          { "nodeId": "github.com/lucasb-eyer/go-colorful" }
         ]
       },
       {
@@ -204,23 +182,15 @@
         "nodeId": "golang.org/x/text/encoding",
         "pkgId": "golang.org/x/text/encoding@0.3.2",
         "deps": [
-          {
-            "nodeId": "golang.org/x/text/transform:pruned"
-          },
-          {
-            "nodeId": "golang.org/x/text/encoding/internal/identifier"
-          }
+          { "nodeId": "golang.org/x/text/transform:pruned" },
+          { "nodeId": "golang.org/x/text/encoding/internal/identifier" }
         ]
       },
       {
         "nodeId": "golang.org/x/text/transform:pruned",
         "pkgId": "golang.org/x/text/transform@0.3.2",
         "deps": [],
-        "info": {
-          "labels": {
-            "pruned": "true"
-          }
-        }
+        "info": { "labels": { "pruned": "true" } }
       },
       {
         "nodeId": "golang.org/x/text/encoding/internal/identifier",
@@ -231,21 +201,13 @@
         "nodeId": "github.com/mattn/go-runewidth:pruned",
         "pkgId": "github.com/mattn/go-runewidth@0.0.4",
         "deps": [],
-        "info": {
-          "labels": {
-            "pruned": "true"
-          }
-        }
+        "info": { "labels": { "pruned": "true" } }
       },
       {
         "nodeId": "github.com/lucasb-eyer/go-colorful:pruned",
         "pkgId": "github.com/lucasb-eyer/go-colorful@1.0.2",
         "deps": [],
-        "info": {
-          "labels": {
-            "pruned": "true"
-          }
-        }
+        "info": { "labels": { "pruned": "true" } }
       },
       {
         "nodeId": "github.com/gdamore/tcell/terminfo",
@@ -256,23 +218,15 @@
         "nodeId": "github.com/gdamore/encoding",
         "pkgId": "github.com/gdamore/encoding@1.0.0",
         "deps": [
-          {
-            "nodeId": "golang.org/x/text/transform:pruned"
-          },
-          {
-            "nodeId": "golang.org/x/text/encoding:pruned"
-          }
+          { "nodeId": "golang.org/x/text/transform:pruned" },
+          { "nodeId": "golang.org/x/text/encoding:pruned" }
         ]
       },
       {
         "nodeId": "golang.org/x/text/encoding:pruned",
         "pkgId": "golang.org/x/text/encoding@0.3.2",
         "deps": [],
-        "info": {
-          "labels": {
-            "pruned": "true"
-          }
-        }
+        "info": { "labels": { "pruned": "true" } }
       },
       {
         "nodeId": "github.com/antlr/antlr4/runtime/Go/antlr",
@@ -282,11 +236,7 @@
       {
         "nodeId": "golang.org/x/text/width",
         "pkgId": "golang.org/x/text/width@0.3.2",
-        "deps": [
-          {
-            "nodeId": "golang.org/x/text/transform"
-          }
-        ]
+        "deps": [{ "nodeId": "golang.org/x/text/transform" }]
       }
     ]
   }

--- a/test/golist.test.ts
+++ b/test/golist.test.ts
@@ -52,7 +52,7 @@ if (goVersion[0] > 1 || goVersion[1] >= 12) {
   test('go list parsing with module information', (t) => {
     t.test('produces dependency graph', async (t) => {
       const expectedDepGraph = JSON.parse(
-        load('gomod-small/expected-gomodules-depgraph.json'),
+        load('gomod-small/expected-gomodules-depgraph-no-purls.json'),
       );
       const depGraphAndNotice = await buildDepGraphFromImportsAndModules(
         `${__dirname}/fixtures/gomod-small`,

--- a/test/purls.test.ts
+++ b/test/purls.test.ts
@@ -57,7 +57,7 @@ test('dependency graph with package urls', async (t) => {
 
   t.test('produces a dependency graph with package urls', async (t) => {
     const expectedDepGraph = JSON.parse(
-      load('gomod-small/expected-gomodules-depgraph-with-purls.json'),
+      load('gomod-small/expected-gomodules-depgraph.json'),
     );
     const depGraph = await buildDepGraphFromImportsAndModules(
       `${__dirname}/fixtures/gomod-small`,
@@ -69,7 +69,7 @@ test('dependency graph with package urls', async (t) => {
 
   t.test('produces a dependency graph without package urls', async (t) => {
     const expectedDepGraph = JSON.parse(
-      load('gomod-small/expected-gomodules-depgraph.json'),
+      load('gomod-small/expected-gomodules-depgraph-no-purls.json'),
     );
     const depGraph = await buildDepGraphFromImportsAndModules(
       `${__dirname}/fixtures/gomod-small`,


### PR DESCRIPTION
#### What does this PR do?

BREAKING CHANGE: The `inspect` function will now enable the generation of PackageURLs (purl) by default. Consumers who wish to diable this functionality have to disable it explicitly through setting `configuration.includePackageUrls` to `false`.