### PR TITLE
fix: upgrade tmp package to fix high vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lookpath": "^1.2.2",
     "packageurl-js": "^2.0.1",
     "snyk-go-parser": "1.13.0",
-    "tmp": "0.2.2",
+    "tmp": "0.2.5",
     "tslib": "^1.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Upgrades the version of `tmp` package from `0.2.2` to `0.2.5` in order to fix  a Command Injection vulnerability [SNYK-JS-GLOB-14040952](https://app.snyk.io/vuln/SNYK-JS-GLOB-14040952) introduced by `glob@10.4.5`

