### PR TITLE
fix: upgrade @snyk/dep-graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "@snyk/dep-graph": "^2.16.3",
+    "@snyk/dep-graph": "^2.16.4",
     "@snyk/graphlib": "2.1.9-patch.3",
     "debug": "^4.1.1",
     "lookpath": "^1.2.2",


### PR DESCRIPTION
#### What does this PR do?

Upgrade `@snyk/dep-graph` to improve dep-graph generation performance. Brings in https://github.com/snyk/dep-graph/pull/149.