### PR TITLE
fix(ci): migrate to NPM OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,11 +149,12 @@ jobs:
       - checkout
       - install_deps
       - run:
-          name: Publish to GitHub
-          command: npx semantic-release
+          name: Release
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            npx semantic-release@25.0.5
 
 workflows:
-  version: 2
   test_and_release:
     jobs:
       - prodsec/secrets-scan:
@@ -197,8 +198,10 @@ workflows:
       # Release
       - release:
           name: Release
-          context: nodejs-app-release
-          node_version: "20.19"
+          context:
+            - nodejs-install
+            - github-release
+          node_version: "22.14"
           requires:
             - test-unix
             - test-windows

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-.github
-.jscsrc
-.travis.yml
-/test

--- a/package.json
+++ b/package.json
@@ -1,14 +1,24 @@
 {
   "name": "snyk-go-plugin",
   "description": "Snyk CLI Golang plugin",
-  "homepage": "https://github.com/snyk/snyk-go-plugin",
+  "homepage": "https://github.com/snyk/snyk-go-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/snyk/snyk-go-plugin/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/snyk/snyk-go-plugin"
+    "url": "https://github.com/snyk/snyk-go-plugin.git"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "engines": {
     "node": ">=20"
   },
+  "files": [
+    "dist",
+    "gosrc"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written
- [x] Commit history is tidy

### What this does

Set up NPM OIDC Trusted Publishing for the package


### Notes for the reviewer

- This package is still used by Snyk products. The repo and the npm package are both public and they will remain this way. 
- Trusted Publishing from CircleCI has been configured. 
- The release group was granted Write access to the repo.
- Removed `.npmignore` file as that is now redundant with the new addition to the package.json of `files'. 


### More information

- [Jira ticket CMPA-552](https://snyksec.atlassian.net/browse/CMPA-552)
