### PR TITLE
feat: [CMPA-650] support includeComponentMetadata for go modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ workflows:
           matrix:
             parameters:
               node_version: ["20", "22", "24"]
-              go_version: ["1.15", "1.16", "1.23", "1.24", "1.25"]
+              go_version: ["1.15", "1.16", "1.24", "1.25", "1.26"]
       - test-windows:
           name: Windows with node v<< matrix.node_version >>, go v<< matrix.go_version >>
           context: nodejs-install
@@ -193,7 +193,7 @@ workflows:
           matrix:
             parameters:
               node_version: ["20", "22", "24"]
-              go_version: ["1.15", "1.16", "1.23", "1.24", "1.25"]
+              go_version: ["1.15", "1.16", "1.24", "1.25", "1.26"]
 
       # Release
       - release:

--- a/lib/component-metadata.ts
+++ b/lib/component-metadata.ts
@@ -1,0 +1,126 @@
+const H1_PREFIX = 'h1:';
+const SHA256_BYTES = 32;
+const DEFAULT_GOPROXY = 'https://proxy.golang.org';
+const GO_MOD_SUFFIX = '/go.mod';
+
+export type GoSumHashes = Record<string, string>;
+
+/**
+ * Parse a go.sum file into a map of `<module>@<version>` -> its file-tree
+ * (`h1:`) hash. go.sum records two lines per module version:
+ *   <module> <version> h1:<base64>=          -> the module .zip hash (kept here)
+ *   <module> <version>/go.mod h1:<base64>=   -> the go.mod hash (ignored)
+ * We read the hash from go.sum rather than `go list` because `Module.Sum` is
+ * only emitted by go >= 1.23, whereas the go.sum format is stable across all
+ * supported go versions. See https://go.dev/ref/mod#go-sum-files
+ */
+export function parseGoSum(goSumContents: string): GoSumHashes {
+  const hashes: GoSumHashes = {};
+  for (const rawLine of goSumContents.split('\n')) {
+    const [modulePath, versionField, hash] = rawLine.trim().split(/\s+/);
+    if (!modulePath || !versionField || !hash) {
+      continue; // blank or malformed line
+    }
+    if (versionField.endsWith(GO_MOD_SUFFIX)) {
+      continue; // go.mod hash, not the module file-tree hash
+    }
+    hashes[`${modulePath}@${versionField}`] = hash;
+  }
+  return hashes;
+}
+
+/**
+ * Build the component-metadata labels for a single Go module version. Produces:
+ *   - `hash:sha-256`     the module's file-tree hash, decoded to lowercase hex
+ *   - `distribution:url` the module proxy download URL for the .zip
+ * `h1` is the module's `h1:` hash as recorded in go.sum. `goproxy` is the
+ * effective GOPROXY value as reported by `go env GOPROXY` (see
+ * buildDistributionUrl). Either label is omitted when it cannot be produced
+ * (missing/invalid hash, or no proxy to derive a URL from).
+ */
+export function getComponentMetadataLabels(
+  modulePath: string,
+  version: string,
+  h1: string | undefined,
+  goproxy?: string,
+): Record<string, string> {
+  const labels: Record<string, string> = {};
+
+  const sha256Hex = decodeH1ToSha256Hex(h1);
+  if (sha256Hex) {
+    labels['hash:sha-256'] = sha256Hex;
+  }
+
+  const distributionUrl = buildDistributionUrl(modulePath, version, goproxy);
+  if (distributionUrl) {
+    labels['distribution:url'] = distributionUrl;
+  }
+
+  return labels;
+}
+
+/**
+ * A go module `h1:` hash is the base64-encoded SHA-256 of the module's dirhash
+ * manifest (see https://go.dev/ref/mod#go-sum-files). SBOM consumers expect a
+ * lowercase hex digest, so decode base64 -> hex. Returns undefined when the
+ * value is missing or not a well-formed 32-byte digest.
+ */
+export function decodeH1ToSha256Hex(h1?: string): string | undefined {
+  if (!h1 || !h1.startsWith(H1_PREFIX)) {
+    return undefined;
+  }
+  const base64 = h1.slice(H1_PREFIX.length);
+  const buf = Buffer.from(base64, 'base64');
+  // Guard against short/garbage input: require an exact SHA-256 digest and a
+  // clean base64 round-trip (Buffer.from is otherwise lenient).
+  if (buf.length !== SHA256_BYTES || buf.toString('base64') !== base64) {
+    return undefined;
+  }
+  return buf.toString('hex');
+}
+
+/**
+ * Derive the module proxy download URL for a module version, e.g.
+ * https://proxy.golang.org/github.com/!burnt!sushi/toml/@v/v1.2.3.zip
+ * `goproxy` is the effective GOPROXY value as reported by `go env GOPROXY`
+ * (which already applies env-var > go-env-file > built-in-default precedence).
+ * Honours it when it points at an http(s) proxy; returns undefined for
+ * `off`/`direct`/private setups where a public URL would be misleading.
+ */
+export function buildDistributionUrl(
+  modulePath: string,
+  version: string,
+  goproxy?: string,
+): string | undefined {
+  const proxy = resolveGoProxyBase(goproxy);
+  if (!proxy) {
+    return undefined;
+  }
+  return `${proxy}/${escapeModulePath(modulePath)}/@v/${escapeModulePath(
+    version,
+  )}.zip`;
+}
+
+function resolveGoProxyBase(goproxy: string | undefined): string | undefined {
+  if (!goproxy) {
+    // `go env GOPROXY` returned nothing (or the lookup failed): fall back to
+    // the public proxy, which is also go's built-in default.
+    return DEFAULT_GOPROXY;
+  }
+  // GOPROXY is a list separated by commas or pipes; the first entry wins.
+  const first = goproxy.split(/[,|]/)[0].trim();
+  if (!/^https?:\/\//.test(first)) {
+    // "off", "direct", "none" or empty: no proxy URL we can safely derive.
+    return undefined;
+  }
+  return first.replace(/\/+$/, '');
+}
+
+/**
+ * Go escapes module paths and versions for case-insensitive filesystems by
+ * replacing each uppercase letter with `!` followed by its lowercase form.
+ * See https://go.dev/ref/mod#goproxy-protocol
+ */
+export function escapeModulePath(value: string): string {
+  return value.replace(/[A-Z]/g, (c) => '!' + c.toLowerCase());
+}

--- a/lib/dep-graph.ts
+++ b/lib/dep-graph.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import { DepGraph, DepGraphBuilder, PkgInfo } from '@snyk/dep-graph';
 
@@ -7,13 +8,22 @@ import { CustomError } from './errors/custom-error';
 import { parseVersion, toSnykVersion } from './version';
 import { runGo } from './sub-process';
 import { createGoPurl } from './package-url';
+import {
+  getComponentMetadataLabels,
+  parseGoSum,
+  GoSumHashes,
+} from './component-metadata';
 
 export async function getDepGraph(
   root: string,
   targetFile: string,
   options: Options = {},
 ): Promise<DepGraph> {
-  const { args: additionalArgs = [], configuration } = options;
+  const {
+    args: additionalArgs = [],
+    configuration,
+    includeComponentMetadata = false,
+  } = options;
 
   const includeGoStandardLibraryDeps =
     configuration?.includeGoStandardLibraryDeps ?? false;
@@ -33,6 +43,7 @@ export async function getDepGraph(
     includeGoStandardLibraryDeps,
     includePackageUrls,
     useReplaceName,
+    includeComponentMetadata,
   });
 }
 
@@ -48,6 +59,24 @@ interface GraphOptions {
    * removed once the rollout is complete.
    **/
   useReplaceName?: boolean;
+  /**
+   * Attach component-metadata labels (hash:sha-256, distribution:url) to
+   * dependency nodes, sourced from go.sum.
+   */
+  includeComponentMetadata?: boolean;
+  /**
+   * Internal: go.sum hashes parsed once and threaded through the recursion so
+   * node builders can look up module hashes. Populated when
+   * includeComponentMetadata is set.
+   */
+  goSumHashes?: GoSumHashes;
+  /**
+   * Internal: effective GOPROXY from `go env GOPROXY`, resolved once and
+   * threaded through so distribution URLs honour the go env file / env var
+   * precedence rather than only the process environment. Populated when
+   * includeComponentMetadata is set.
+   */
+  goProxy?: string;
 }
 
 export async function buildDepGraphFromImportsAndModules(
@@ -65,8 +94,14 @@ export async function buildDepGraphFromImportsAndModules(
     includeGoStandardLibraryDeps: false,
     includePackageUrls: false,
     useReplaceName: false,
+    includeComponentMetadata: false,
     ...options,
   };
+
+  if (options.includeComponentMetadata) {
+    options.goSumHashes = readGoSum(root, targetFile);
+    options.goProxy = await readGoProxy(root, targetFile);
+  }
 
   let rootPkg = createPkgInfo(projectName, projectVersion, options);
 
@@ -191,6 +226,8 @@ export function buildGraph(
         pkg.Module,
       );
 
+      const componentLabels = getComponentLabelsForModule(pkg.Module, options);
+
       const currentChildren = childrenChain.get(currentParent) || [];
       const currentAncestors = ancestorsChain.get(currentParent) || [];
       const isAncestorOrChild =
@@ -205,13 +242,19 @@ export function buildGraph(
       if (localVisited.has(packageImport)) {
         const prunedId = `${packageImport}:pruned`;
         depGraphBuilder.addPkgNode(newNode, prunedId, {
-          labels: { pruned: 'true' },
+          labels: { pruned: 'true', ...componentLabels },
         });
         depGraphBuilder.connectDep(currentParent, prunedId);
         continue;
       }
 
-      depGraphBuilder.addPkgNode(newNode, packageImport);
+      depGraphBuilder.addPkgNode(
+        newNode,
+        packageImport,
+        Object.keys(componentLabels).length > 0
+          ? { labels: componentLabels }
+          : undefined,
+      );
       depGraphBuilder.connectDep(currentParent, packageImport);
       localVisited.add(packageImport);
 
@@ -234,6 +277,64 @@ export function buildGraph(
       }
     }
   }
+}
+
+// Read and parse the go.sum sitting alongside the target go.mod. A missing or
+// unreadable go.sum is not fatal: component metadata is best-effort, so we
+// return an empty map and carry on.
+function readGoSum(root: string, targetFile: string): GoSumHashes {
+  const goSumPath = path.resolve(root, path.dirname(targetFile), 'go.sum');
+  try {
+    return parseGoSum(fs.readFileSync(goSumPath, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+// Resolve the effective GOPROXY via `go env GOPROXY`, which applies go's own
+// precedence (env var > go env file > built-in default) — unlike reading
+// process.env.GOPROXY, which misses values set with `go env -w`. Returns
+// undefined if the lookup fails so URL derivation can fall back to the default.
+async function readGoProxy(
+  root: string,
+  targetFile: string,
+): Promise<string | undefined> {
+  try {
+    const cwd = path.resolve(root, path.dirname(targetFile));
+    const out = await runGo(['env', 'GOPROXY'], { cwd });
+    return out.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Resolve the component-metadata labels for the module a package belongs to.
+// Returns {} unless the feature is enabled and we have a module. Uses the
+// replacement module when present, since that is what actually gets downloaded
+// and recorded in go.sum. The module hash is preferred from `go list`'s
+// Module.Sum (go >= 1.23), falling back to the go.sum file for older toolchains
+// that do not emit it. Both key on the raw (un-normalised) module version, so
+// we deliberately avoid toSnykVersion here.
+function getComponentLabelsForModule(
+  goModule: GoModule | undefined,
+  options: GraphOptions,
+): Record<string, string> {
+  if (!options.includeComponentMetadata || !goModule) {
+    return {};
+  }
+
+  const replace = goModule.Replace;
+  const useReplaceInfo = replace?.Path && replace?.Version;
+  const modulePath = useReplaceInfo ? replace.Path : goModule.Path;
+  const version = useReplaceInfo ? replace.Version : goModule.Version;
+  if (!modulePath || !version) {
+    return {};
+  }
+
+  const h1 =
+    (useReplaceInfo ? replace.Sum : goModule.Sum) ||
+    options.goSumHashes?.[`${modulePath}@${version}`];
+  return getComponentMetadataLabels(modulePath, version, h1, options.goProxy);
 }
 
 function extractAllImports(goDeps: GoPackage[]): string[] {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,6 +22,15 @@ export interface Options {
   debug?: boolean;
   file?: string;
   args?: string[];
+  /**
+   * Attach component-metadata labels (hash:sha-256, distribution:url) to
+   * dependency nodes, sourced from go.sum and the Go module proxy.
+   *
+   * Read at the top level (not under `configuration`) to match the shared
+   * convention used by the other plugins (snyk-mvn-plugin,
+   * snyk-nodejs-plugin, ...); the CLI injects it top-level for all plugins.
+   */
+  includeComponentMetadata?: boolean;
   configuration?: {
     includeGoStandardLibraryDeps?: boolean;
     includePackageUrls?: boolean;
@@ -94,6 +103,8 @@ export interface GoModule {
   Indirect: boolean; // is this module only an indirect dependency of main module?
   Dir: string; // directory holding files for this module, if any
   GoMod: string; // path to go.mod file for this module, if any
+  Sum: string; // checksum for path, version (as in go.sum); go >= 1.23 only
+  GoModSum: string; // checksum for go.mod (as in go.sum); go >= 1.23 only
   Error: string; // error loading module
 }
 

--- a/test/component-metadata-graph.test.ts
+++ b/test/component-metadata-graph.test.ts
@@ -1,0 +1,94 @@
+import { test } from 'tap';
+
+import { buildDepGraphFromImportsAndModules, inspect } from '../lib';
+
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+// Ensure the module proxy URL is deterministic regardless of the host's GOPROXY.
+test('component metadata labels on the go modules graph', async (t) => {
+  const originalGoProxy = process.env.GOPROXY;
+  process.env.GOPROXY = 'https://proxy.golang.org';
+  t.teardown(() => {
+    if (originalGoProxy === undefined) {
+      delete process.env.GOPROXY;
+    } else {
+      process.env.GOPROXY = originalGoProxy;
+    }
+  });
+
+  const build = (includeComponentMetadata: boolean) =>
+    buildDepGraphFromImportsAndModules(
+      `${__dirname}/fixtures/gomod-small`,
+      undefined,
+      { includePackageUrls: true, includeComponentMetadata },
+    );
+
+  const withMetadata = (await build(true)).toJSON();
+  const withoutMetadata = (await build(false)).toJSON();
+
+  const labelsOf = (json: any) =>
+    json.graph.nodes.map((n: any) => n.info?.labels || {});
+
+  // The flag only adds labels; the graph shape is unchanged.
+  t.equal(
+    withMetadata.graph.nodes.length,
+    withoutMetadata.graph.nodes.length,
+    'node count is unchanged',
+  );
+
+  const hashed = labelsOf(withMetadata).filter((l: any) => l['hash:sha-256']);
+  t.ok(hashed.length > 0, 'at least one node carries a hash:sha-256 label');
+  for (const l of hashed) {
+    t.match(l['hash:sha-256'], SHA256_HEX, 'hash is a lowercase sha-256 hex');
+    t.match(
+      l['distribution:url'],
+      /^https:\/\/proxy\.golang\.org\/.+\/@v\/.+\.zip$/,
+      'distribution url points at the module proxy',
+    );
+  }
+
+  // Disabled: no component metadata labels at all (pruned labels may remain).
+  for (const l of labelsOf(withoutMetadata)) {
+    t.notOk(l['hash:sha-256'], 'no hash label when disabled');
+    t.notOk(l['distribution:url'], 'no distribution url when disabled');
+  }
+});
+
+// Exercises the full plugin (`inspect`) with the CLI-facing option shape:
+// `includeComponentMetadata` at the top level, matching how the CLI forwards
+// it (get-single-plugin-result.ts) and how the other plugins read it
+// (snyk-mvn-plugin, snyk-nodejs-plugin). This is the path the unit test above
+// does not cover, since it calls the internal builder with a flat shape.
+test('inspect() reads includeComponentMetadata from the top level', async (t) => {
+  const originalGoProxy = process.env.GOPROXY;
+  process.env.GOPROXY = 'https://proxy.golang.org';
+  t.teardown(() => {
+    if (originalGoProxy === undefined) {
+      delete process.env.GOPROXY;
+    } else {
+      process.env.GOPROXY = originalGoProxy;
+    }
+  });
+
+  const root = `${__dirname}/fixtures/gomod-small`;
+  const hashCount = async (options: any) => {
+    const { dependencyGraph } = await inspect(root, 'go.mod', options);
+    return dependencyGraph!
+      .toJSON()
+      .graph.nodes.filter((n: any) => n.info?.labels?.['hash:sha-256']).length;
+  };
+
+  t.ok(
+    (await hashCount({ includeComponentMetadata: true })) > 0,
+    'top-level includeComponentMetadata attaches hash:sha-256 labels',
+  );
+
+  // Regression guard: the flag no longer lives under `configuration`, so a
+  // nested value must be ignored — keeps the plugin aligned with the shared
+  // top-level convention used by the other plugins.
+  t.equal(
+    await hashCount({ configuration: { includeComponentMetadata: true } }),
+    0,
+    'nested configuration.includeComponentMetadata is ignored',
+  );
+});

--- a/test/component-metadata.test.ts
+++ b/test/component-metadata.test.ts
@@ -1,0 +1,149 @@
+import { test } from 'tap';
+import {
+  decodeH1ToSha256Hex,
+  escapeModulePath,
+  buildDistributionUrl,
+  getComponentMetadataLabels,
+  parseGoSum,
+} from '../lib/component-metadata';
+
+// h1 value taken from a real go.sum (golang.org/x/text v0.3.2), with its
+// base64 payload decoded to hex out of band.
+const H1 = 'h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=';
+const H1_HEX =
+  'b56d9b9a206ac20263fd4a6ab42f04a571195583b0534c86e2259ba6b49501cb';
+
+test('parseGoSum', async (t) => {
+  const hashes = parseGoSum(
+    [
+      'github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=',
+      'github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=',
+      'github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=',
+      '',
+      'garbage line',
+      'golang.org/x/text v0.3.2 ' + H1,
+    ].join('\n'),
+  );
+
+  t.equal(
+    hashes['github.com/davecgh/go-spew@v1.1.0'],
+    'h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=',
+    'keeps the module file-tree hash',
+  );
+  t.equal(hashes['golang.org/x/text@v0.3.2'], H1);
+  t.notOk(
+    hashes['github.com/stretchr/objx@v0.1.0'],
+    'ignores go.mod-only entries',
+  );
+});
+
+test('decodeH1ToSha256Hex', async (t) => {
+  t.equal(
+    decodeH1ToSha256Hex(H1),
+    H1_HEX,
+    'decodes a valid h1 to lowercase hex',
+  );
+  t.equal(decodeH1ToSha256Hex(undefined), undefined, 'undefined input');
+  t.equal(
+    decodeH1ToSha256Hex('tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs='),
+    undefined,
+    'missing h1: prefix',
+  );
+  t.equal(
+    decodeH1ToSha256Hex('h1:c2hvcnQ='),
+    undefined,
+    'decodes to fewer than 32 bytes',
+  );
+  t.equal(
+    decodeH1ToSha256Hex('h1:not valid base64!!'),
+    undefined,
+    'malformed base64',
+  );
+});
+
+test('escapeModulePath', async (t) => {
+  t.equal(
+    escapeModulePath('github.com/BurntSushi/toml'),
+    'github.com/!burnt!sushi/toml',
+    'uppercase letters become !lowercase',
+  );
+  t.equal(
+    escapeModulePath('golang.org/x/text'),
+    'golang.org/x/text',
+    'all-lowercase path is unchanged',
+  );
+});
+
+test('buildDistributionUrl', async (t) => {
+  t.test('defaults to proxy.golang.org when GOPROXY is empty', async (t) => {
+    t.equal(
+      buildDistributionUrl('golang.org/x/text', 'v0.3.2', undefined),
+      'https://proxy.golang.org/golang.org/x/text/@v/v0.3.2.zip',
+    );
+  });
+
+  t.test('honours an http(s) GOPROXY, taking the first entry', async (t) => {
+    t.equal(
+      buildDistributionUrl(
+        'golang.org/x/text',
+        'v0.3.2',
+        'https://corp.example.com/goproxy/,direct',
+      ),
+      'https://corp.example.com/goproxy/golang.org/x/text/@v/v0.3.2.zip',
+      'trailing slash trimmed, first list entry used',
+    );
+  });
+
+  t.test('returns undefined for off/direct', async (t) => {
+    t.equal(
+      buildDistributionUrl('golang.org/x/text', 'v0.3.2', 'off'),
+      undefined,
+    );
+    t.equal(
+      buildDistributionUrl('golang.org/x/text', 'v0.3.2', 'direct'),
+      undefined,
+    );
+  });
+});
+
+test('getComponentMetadataLabels', async (t) => {
+  t.test(
+    'emits hash and distribution url when the module hash is known',
+    async (t) => {
+      const labels = getComponentMetadataLabels(
+        'golang.org/x/text',
+        'v0.3.2',
+        H1,
+        undefined,
+      );
+      t.strictSame(labels, {
+        'hash:sha-256': H1_HEX,
+        'distribution:url':
+          'https://proxy.golang.org/golang.org/x/text/@v/v0.3.2.zip',
+      });
+    },
+  );
+
+  t.test('omits the hash when the module has no hash', async (t) => {
+    const labels = getComponentMetadataLabels(
+      'golang.org/x/text',
+      'v0.3.2',
+      undefined,
+      undefined,
+    );
+    t.strictSame(labels, {
+      'distribution:url':
+        'https://proxy.golang.org/golang.org/x/text/@v/v0.3.2.zip',
+    });
+  });
+
+  t.test('omits the url when GOPROXY offers nothing to derive', async (t) => {
+    const labels = getComponentMetadataLabels(
+      'golang.org/x/text',
+      'v0.3.2',
+      H1,
+      'off',
+    );
+    t.strictSame(labels, { 'hash:sha-256': H1_HEX });
+  });
+});

--- a/test/go-standard-library-packages.test.ts
+++ b/test/go-standard-library-packages.test.ts
@@ -59,3 +59,32 @@ test('std-lib inclusion flag works for fixture: gomod-simple', async (t) => {
     'fmt not present when flag off',
   );
 });
+
+// Standard library packages are toolchain-provided, not proxy-distributed and
+// with no go.sum/Module.Sum hash, so they must never carry component-metadata
+// labels — even with includeComponentMetadata enabled. Guards against a future
+// change accidentally attaching a bogus proxy URL / hash to std nodes.
+test('std-lib packages carry no component-metadata labels', async (t) => {
+  const { dependencyGraph } = await inspect(
+    path.join(__dirname, 'fixtures', 'gomod-simple'),
+    targetFile,
+    {
+      configuration: { includeGoStandardLibraryDeps: true },
+      includeComponentMetadata: true,
+    } as any,
+  );
+
+  const stdNodes = dependencyGraph!
+    .toJSON()
+    .graph.nodes.filter((n) => n.pkgId.startsWith('std/'));
+
+  t.ok(stdNodes.length > 0, 'graph contains standard library nodes to check');
+  for (const node of stdNodes) {
+    const labels = node.info?.labels || {};
+    t.notOk(labels['hash:sha-256'], `${node.pkgId} has no hash:sha-256 label`);
+    t.notOk(
+      labels['distribution:url'],
+      `${node.pkgId} has no distribution:url label`,
+    );
+  }
+});


### PR DESCRIPTION
## What

Adds support for the `includeComponentMetadata` option (already supported by `snyk-mvn-plugin` and `snyk-nodejs-plugin`). The flag is read at the **top level** of the plugin options — not under `configuration` — matching how those plugins and the CLI (`get-single-plugin-result.ts`) already pass it. When set, dependency nodes in the go modules dep-graph get two labels:

- `hash:sha-256` — the module's integrity hash
- `distribution:url` — where the module can be downloaded

Off by default; the graph shape is unchanged when disabled.

## Why

Downstream SBOM generation (`sbom-export`) reads these labels to populate CycloneDX `component.hashes` / `externalReferences` and SPDX `PackageChecksums` / `PackageDownloadLocation`. Go modules currently produce neither, so Go SBOMs lack hashes and download locations.

## How

- **Hashes.** Go records each module's integrity as an `h1:<base64>` value whose payload is a SHA-256 digest. We base64-decode it to lowercase hex — the form SBOM consumers require, and what `cyclonedx-gomod` emits. The value is read from `go list`'s `Module.Sum` when present, and **falls back to parsing the sibling `go.sum`** otherwise. This matters because `Module.Sum` was only added to `go list` output in **go 1.23**, whereas the `go.sum` format is stable across all supported toolchains — so the feature works regardless of the go version a project is built with. Uses the raw module version and the replacement module for replaced deps, mirroring the existing purl/version logic.
- **Distribution URLs** are derived from the Go module proxy: `<GOPROXY>/<escaped-module>/@v/<escaped-version>.zip`. The effective `GOPROXY` is resolved via **`go env GOPROXY`** rather than reading `process.env.GOPROXY`, so proxy settings persisted with `go env -w` (common in enterprise setups) are honoured — not just the shell env var. `go env` applies go's own precedence (env var > go env file > built-in default) and reports the correct default for the installed toolchain. Uses the first http(s) entry, defaulting to `proxy.golang.org`; skipped for `off`/`direct`, where a public URL would be misleading.
- A module without a hash (e.g. a local `replace => ./dir`) simply gets no hash label; a missing/unreadable `go.sum` is non-fatal.

## CI

Refreshes the go matrix: drop `1.23`, add `1.26`. `1.15`/`1.16` are kept deliberately — they exercise the go.sum fallback path (no `Module.Sum`), while `1.24`–`1.26` exercise the native `Module.Sum` path.

## Notes / follow-ups

- Scope is the go modules (`go.mod`) path only; the legacy dep/govendor formats produce a `DepTree` and have no module hashes.
- **Caller enablement:** the CLI already forwards `includeComponentMetadata` to the plugin at the top level (`get-single-plugin-result.ts`, gateway/feature-flag driven), and the SBOM path enables it via `cli-extension-sbom` feature-flag configuration. No plugin-side `configuration` wiring is required.
- **Not yet covered:** `GONOPROXY`/`GOPRIVATE` are not consulted, so a private module (fetched direct, absent from the public proxy) still gets a `proxy.golang.org` `distribution:url` that will 404. `hash:sha-256` is unaffected. Tracked as a follow-up.
