### PR TITLE
fix: strip embedded credentials from GOPROXY before building distribution:url

### DIFF
--- a/lib/component-metadata.ts
+++ b/lib/component-metadata.ts
@@ -113,7 +113,18 @@ function resolveGoProxyBase(goproxy: string | undefined): string | undefined {
     // "off", "direct", "none" or empty: no proxy URL we can safely derive.
     return undefined;
   }
-  return first.replace(/\/+$/, '');
+  let parsed: URL;
+  try {
+    parsed = new URL(first);
+  } catch {
+    return undefined;
+  }
+  // Private GOPROXY setups sometimes embed basic-auth credentials in the URL
+  // (e.g. https://user:pass@proxy.corp/). Strip them so they never end up in
+  // component metadata, which is attached to scan results and shipped off-host.
+  parsed.username = '';
+  parsed.password = '';
+  return parsed.toString().replace(/\/+$/, '');
 }
 
 /**

--- a/test/component-metadata.test.ts
+++ b/test/component-metadata.test.ts
@@ -104,6 +104,21 @@ test('buildDistributionUrl', async (t) => {
       undefined,
     );
   });
+
+  t.test(
+    'strips basic-auth credentials embedded in the GOPROXY url',
+    async (t) => {
+      t.equal(
+        buildDistributionUrl(
+          'golang.org/x/text',
+          'v0.3.2',
+          'https://foo:bar@corp.example.com/goproxy/',
+        ),
+        'https://corp.example.com/goproxy/golang.org/x/text/@v/v0.3.2.zip',
+        'credentials must never end up in component metadata',
+      );
+    },
+  );
 });
 
 test('getComponentMetadataLabels', async (t) => {


### PR DESCRIPTION
## Summary
- `includeComponentMetadata` (#148) derives a `distribution:url` label from the effective `go env GOPROXY` value. Private GOPROXY setups sometimes embed basic-auth credentials directly in the URL (e.g. `https://user:pass@proxy.corp/`). `resolveGoProxyBase` was passing that value through verbatim, so credentials would end up attached to dep-graph nodes and shipped off-host with scan results/SBOMs.
- Parse the proxy URL with `URL` and clear `username`/`password` before using it.

## Test plan
- [x] `npx tap test/component-metadata.test.ts` — 18/18 passing, including a new case asserting credentials are stripped from the derived `distribution:url`.
