### PR TITLE
feat: report vcs:url instead of proxy distribution:url for go modules

### DIFF
--- a/lib/component-metadata.ts
+++ b/lib/component-metadata.ts
@@ -1,7 +1,13 @@
 const H1_PREFIX = 'h1:';
 const SHA256_BYTES = 32;
-const DEFAULT_GOPROXY = 'https://proxy.golang.org';
 const GO_MOD_SUFFIX = '/go.mod';
+
+// Hosts whose module path prefix maps directly onto a repository root, so a
+// VCS URL can be derived from the module path alone (host/owner/repo). Vanity
+// import paths (rsc.io, k8s.io, google.golang.org, gopkg.in, ...) do NOT map
+// this way and are deliberately excluded — for those we only emit a vcs:url
+// when go's own Origin metadata resolves it (see buildVcsUrl).
+const KNOWN_VCS_HOSTS = new Set(['github.com', 'gitlab.com', 'bitbucket.org']);
 
 export type GoSumHashes = Record<string, string>;
 
@@ -31,18 +37,17 @@ export function parseGoSum(goSumContents: string): GoSumHashes {
 
 /**
  * Build the component-metadata labels for a single Go module version. Produces:
- *   - `hash:sha-256`     the module's file-tree hash, decoded to lowercase hex
- *   - `distribution:url` the module proxy download URL for the .zip
- * `h1` is the module's `h1:` hash as recorded in go.sum. `goproxy` is the
- * effective GOPROXY value as reported by `go env GOPROXY` (see
- * buildDistributionUrl). Either label is omitted when it cannot be produced
- * (missing/invalid hash, or no proxy to derive a URL from).
+ *   - `hash:sha-256` the module's file-tree hash, decoded to lowercase hex
+ *   - `vcs:url`      the source repository URL for the module
+ * `h1` is the module's `h1:` hash as recorded in go.sum. `originUrl` is the
+ * repository URL from go's Origin metadata when available (see buildVcsUrl).
+ * Either label is omitted when it cannot be produced (missing/invalid hash, or
+ * no VCS URL that can be resolved).
  */
 export function getComponentMetadataLabels(
   modulePath: string,
-  version: string,
   h1: string | undefined,
-  goproxy?: string,
+  originUrl?: string,
 ): Record<string, string> {
   const labels: Record<string, string> = {};
 
@@ -51,9 +56,9 @@ export function getComponentMetadataLabels(
     labels['hash:sha-256'] = sha256Hex;
   }
 
-  const distributionUrl = buildDistributionUrl(modulePath, version, goproxy);
-  if (distributionUrl) {
-    labels['distribution:url'] = distributionUrl;
+  const vcsUrl = buildVcsUrl(modulePath, originUrl);
+  if (vcsUrl) {
+    labels['vcs:url'] = vcsUrl;
   }
 
   return labels;
@@ -80,58 +85,56 @@ export function decodeH1ToSha256Hex(h1?: string): string | undefined {
 }
 
 /**
- * Derive the module proxy download URL for a module version, e.g.
- * https://proxy.golang.org/github.com/!burnt!sushi/toml/@v/v1.2.3.zip
- * `goproxy` is the effective GOPROXY value as reported by `go env GOPROXY`
- * (which already applies env-var > go-env-file > built-in-default precedence).
- * Honours it when it points at an http(s) proxy; returns undefined for
- * `off`/`direct`/private setups where a public URL would be misleading.
+ * Resolve the source repository URL for a module version.
+ *
+ * Go records nothing about which GOPROXY entry served a module, so a proxy
+ * download URL cannot be attributed reliably. The VCS location, however, is
+ * stable provenance. We resolve it best-effort:
+ *   1. `originUrl` — go's own Origin metadata (VCS URL), which is authoritative
+ *      and resolves vanity paths (e.g. rsc.io/quote -> github.com/rsc/quote).
+ *      Only present when the module was fetched `direct` or from a proxy that
+ *      serves origin data; the public proxy.golang.org does not.
+ *   2. otherwise derive host/owner/repo from the module path for well-known
+ *      VCS hosts (see KNOWN_VCS_HOSTS).
+ * Returns undefined when neither yields a URL (e.g. a vanity path fetched via a
+ * proxy), rather than guessing a URL that would be misleading.
  */
-export function buildDistributionUrl(
+export function buildVcsUrl(
   modulePath: string,
-  version: string,
-  goproxy?: string,
+  originUrl?: string,
 ): string | undefined {
-  const proxy = resolveGoProxyBase(goproxy);
-  if (!proxy) {
-    return undefined;
-  }
-  return `${proxy}/${escapeModulePath(modulePath)}/@v/${escapeModulePath(
-    version,
-  )}.zip`;
+  return normalizeVcsUrl(originUrl) ?? deriveVcsUrlFromModulePath(modulePath);
 }
 
-function resolveGoProxyBase(goproxy: string | undefined): string | undefined {
-  if (!goproxy) {
-    // `go env GOPROXY` returned nothing (or the lookup failed): fall back to
-    // the public proxy, which is also go's built-in default.
-    return DEFAULT_GOPROXY;
-  }
-  // GOPROXY is a list separated by commas or pipes; the first entry wins.
-  const first = goproxy.split(/[,|]/)[0].trim();
-  if (!/^https?:\/\//.test(first)) {
-    // "off", "direct", "none" or empty: no proxy URL we can safely derive.
+// Sanitise a repository URL from go's Origin metadata: keep only http(s) URLs,
+// strip any embedded basic-auth credentials (they must never reach component
+// metadata, which is shipped off-host) and drop trailing slashes. Returns
+// undefined for anything that is not a parseable http(s) URL (e.g. ssh/scp
+// git remotes), leaving the caller to fall back to the path heuristic.
+function normalizeVcsUrl(originUrl?: string): string | undefined {
+  if (!originUrl || !/^https?:\/\//.test(originUrl)) {
     return undefined;
   }
   let parsed: URL;
   try {
-    parsed = new URL(first);
+    parsed = new URL(originUrl);
   } catch {
     return undefined;
   }
-  // Private GOPROXY setups sometimes embed basic-auth credentials in the URL
-  // (e.g. https://user:pass@proxy.corp/). Strip them so they never end up in
-  // component metadata, which is attached to scan results and shipped off-host.
   parsed.username = '';
   parsed.password = '';
   return parsed.toString().replace(/\/+$/, '');
 }
 
-/**
- * Go escapes module paths and versions for case-insensitive filesystems by
- * replacing each uppercase letter with `!` followed by its lowercase form.
- * See https://go.dev/ref/mod#goproxy-protocol
- */
-export function escapeModulePath(value: string): string {
-  return value.replace(/[A-Z]/g, (c) => '!' + c.toLowerCase());
+// Derive a repository URL from a module path for well-known VCS hosts, where
+// the repo root is host/owner/repo. This naturally handles submodule paths
+// (github.com/o/r/sub) and the semantic-import-versioning suffix
+// (github.com/o/r/v2), since both keep the repo root in the first three
+// segments. Returns undefined for any other host.
+function deriveVcsUrlFromModulePath(modulePath: string): string | undefined {
+  const [host, owner, repo] = modulePath.split('/');
+  if (!KNOWN_VCS_HOSTS.has(host) || !owner || !repo) {
+    return undefined;
+  }
+  return `https://${host}/${owner}/${repo}`;
 }

--- a/lib/dep-graph.ts
+++ b/lib/dep-graph.ts
@@ -60,7 +60,7 @@ interface GraphOptions {
    **/
   useReplaceName?: boolean;
   /**
-   * Attach component-metadata labels (hash:sha-256, distribution:url) to
+   * Attach component-metadata labels (hash:sha-256, vcs:url) to
    * dependency nodes, sourced from go.sum.
    */
   includeComponentMetadata?: boolean;
@@ -70,13 +70,6 @@ interface GraphOptions {
    * includeComponentMetadata is set.
    */
   goSumHashes?: GoSumHashes;
-  /**
-   * Internal: effective GOPROXY from `go env GOPROXY`, resolved once and
-   * threaded through so distribution URLs honour the go env file / env var
-   * precedence rather than only the process environment. Populated when
-   * includeComponentMetadata is set.
-   */
-  goProxy?: string;
 }
 
 export async function buildDepGraphFromImportsAndModules(
@@ -100,7 +93,6 @@ export async function buildDepGraphFromImportsAndModules(
 
   if (options.includeComponentMetadata) {
     options.goSumHashes = readGoSum(root, targetFile);
-    options.goProxy = await readGoProxy(root, targetFile);
   }
 
   let rootPkg = createPkgInfo(projectName, projectVersion, options);
@@ -291,18 +283,24 @@ function readGoSum(root: string, targetFile: string): GoSumHashes {
   }
 }
 
-// Resolve the effective GOPROXY via `go env GOPROXY`, which applies go's own
-// precedence (env var > go env file > built-in default) — unlike reading
-// process.env.GOPROXY, which misses values set with `go env -w`. Returns
-// undefined if the lookup fails so URL derivation can fall back to the default.
-async function readGoProxy(
-  root: string,
-  targetFile: string,
-): Promise<string | undefined> {
+// Read the source repository URL from go's Origin metadata for an already
+// downloaded module. `goMod` is `Module.GoMod` from `go list`, which points at
+// `<cache>/download/<mod>/@v/<version>.mod`; the sibling `<version>.info` file
+// carries the Origin block (VCS/URL/Ref/Hash) when the module was fetched
+// `direct` or from a proxy that serves origin data. This is a plain on-disk
+// read of the existing module cache — no network and no extra `go` invocation.
+// Returns undefined whenever Origin is absent or the file cannot be read/parsed
+// (e.g. the common proxy.golang.org case, which serves no origin metadata), so
+// URL resolution falls back to the module-path heuristic.
+function readModuleOriginUrl(goMod: string | undefined): string | undefined {
+  if (!goMod || !goMod.endsWith('.mod')) {
+    return undefined;
+  }
+  const infoPath = goMod.slice(0, -'.mod'.length) + '.info';
   try {
-    const cwd = path.resolve(root, path.dirname(targetFile));
-    const out = await runGo(['env', 'GOPROXY'], { cwd });
-    return out.trim() || undefined;
+    const info = JSON.parse(fs.readFileSync(infoPath, 'utf8'));
+    const url = info?.Origin?.URL;
+    return typeof url === 'string' ? url : undefined;
   } catch {
     return undefined;
   }
@@ -325,16 +323,16 @@ function getComponentLabelsForModule(
 
   const replace = goModule.Replace;
   const useReplaceInfo = replace?.Path && replace?.Version;
-  const modulePath = useReplaceInfo ? replace.Path : goModule.Path;
-  const version = useReplaceInfo ? replace.Version : goModule.Version;
+  const module = useReplaceInfo ? replace : goModule;
+  const modulePath = module.Path;
+  const version = module.Version;
   if (!modulePath || !version) {
     return {};
   }
 
-  const h1 =
-    (useReplaceInfo ? replace.Sum : goModule.Sum) ||
-    options.goSumHashes?.[`${modulePath}@${version}`];
-  return getComponentMetadataLabels(modulePath, version, h1, options.goProxy);
+  const h1 = module.Sum || options.goSumHashes?.[`${modulePath}@${version}`];
+  const originUrl = readModuleOriginUrl(module.GoMod);
+  return getComponentMetadataLabels(modulePath, h1, originUrl);
 }
 
 function extractAllImports(goDeps: GoPackage[]): string[] {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,8 +23,8 @@ export interface Options {
   file?: string;
   args?: string[];
   /**
-   * Attach component-metadata labels (hash:sha-256, distribution:url) to
-   * dependency nodes, sourced from go.sum and the Go module proxy.
+   * Attach component-metadata labels (hash:sha-256, vcs:url) to
+   * dependency nodes, sourced from go.sum and the Go module cache.
    *
    * Read at the top level (not under `configuration`) to match the shared
    * convention used by the other plugins (snyk-mvn-plugin,

--- a/test/component-metadata-graph.test.ts
+++ b/test/component-metadata-graph.test.ts
@@ -40,17 +40,27 @@ test('component metadata labels on the go modules graph', async (t) => {
   t.ok(hashed.length > 0, 'at least one node carries a hash:sha-256 label');
   for (const l of hashed) {
     t.match(l['hash:sha-256'], SHA256_HEX, 'hash is a lowercase sha-256 hex');
+  }
+
+  // The fixture depends on github.com modules, whose vcs:url is derived from
+  // the module path (the public proxy serves no origin metadata). Assert at
+  // least one such repo URL is present and well formed.
+  const vcsUrls = labelsOf(withMetadata)
+    .map((l: any) => l['vcs:url'])
+    .filter(Boolean);
+  t.ok(vcsUrls.length > 0, 'at least one node carries a vcs:url label');
+  for (const url of vcsUrls) {
     t.match(
-      l['distribution:url'],
-      /^https:\/\/proxy\.golang\.org\/.+\/@v\/.+\.zip$/,
-      'distribution url points at the module proxy',
+      url,
+      /^https:\/\/(github\.com|gitlab\.com|bitbucket\.org)\/[^/]+\/[^/]+$/,
+      'vcs url is a repo root on a known host',
     );
   }
 
   // Disabled: no component metadata labels at all (pruned labels may remain).
   for (const l of labelsOf(withoutMetadata)) {
     t.notOk(l['hash:sha-256'], 'no hash label when disabled');
-    t.notOk(l['distribution:url'], 'no distribution url when disabled');
+    t.notOk(l['vcs:url'], 'no vcs url when disabled');
   }
 });
 

--- a/test/component-metadata.test.ts
+++ b/test/component-metadata.test.ts
@@ -1,8 +1,7 @@
 import { test } from 'tap';
 import {
   decodeH1ToSha256Hex,
-  escapeModulePath,
-  buildDistributionUrl,
+  buildVcsUrl,
   getComponentMetadataLabels,
   parseGoSum,
 } from '../lib/component-metadata';
@@ -61,103 +60,111 @@ test('decodeH1ToSha256Hex', async (t) => {
   );
 });
 
-test('escapeModulePath', async (t) => {
-  t.equal(
-    escapeModulePath('github.com/BurntSushi/toml'),
-    'github.com/!burnt!sushi/toml',
-    'uppercase letters become !lowercase',
-  );
-  t.equal(
-    escapeModulePath('golang.org/x/text'),
-    'golang.org/x/text',
-    'all-lowercase path is unchanged',
-  );
-});
-
-test('buildDistributionUrl', async (t) => {
-  t.test('defaults to proxy.golang.org when GOPROXY is empty', async (t) => {
+test('buildVcsUrl', async (t) => {
+  t.test('prefers go Origin metadata when present', async (t) => {
     t.equal(
-      buildDistributionUrl('golang.org/x/text', 'v0.3.2', undefined),
-      'https://proxy.golang.org/golang.org/x/text/@v/v0.3.2.zip',
+      buildVcsUrl('rsc.io/quote', 'https://github.com/rsc/quote'),
+      'https://github.com/rsc/quote',
+      'origin resolves a vanity path the module path alone cannot',
     );
   });
 
-  t.test('honours an http(s) GOPROXY, taking the first entry', async (t) => {
+  t.test('trims a trailing slash from the origin url', async (t) => {
     t.equal(
-      buildDistributionUrl(
-        'golang.org/x/text',
-        'v0.3.2',
-        'https://corp.example.com/goproxy/,direct',
+      buildVcsUrl('example.com/mod', 'https://git.example.com/team/mod/'),
+      'https://git.example.com/team/mod',
+    );
+  });
+
+  t.test('strips basic-auth credentials from the origin url', async (t) => {
+    t.equal(
+      buildVcsUrl(
+        'example.com/mod',
+        'https://foo:bar@git.example.com/team/mod',
       ),
-      'https://corp.example.com/goproxy/golang.org/x/text/@v/v0.3.2.zip',
-      'trailing slash trimmed, first list entry used',
+      'https://git.example.com/team/mod',
+      'credentials must never end up in component metadata',
     );
   });
 
-  t.test('returns undefined for off/direct', async (t) => {
+  t.test('derives a url from the module path for known hosts', async (t) => {
     t.equal(
-      buildDistributionUrl('golang.org/x/text', 'v0.3.2', 'off'),
-      undefined,
+      buildVcsUrl('github.com/pkg/errors', undefined),
+      'https://github.com/pkg/errors',
     );
     t.equal(
-      buildDistributionUrl('golang.org/x/text', 'v0.3.2', 'direct'),
-      undefined,
+      buildVcsUrl('gitlab.com/team/project', undefined),
+      'https://gitlab.com/team/project',
+    );
+    t.equal(
+      buildVcsUrl('bitbucket.org/team/repo', undefined),
+      'https://bitbucket.org/team/repo',
     );
   });
 
-  t.test(
-    'strips basic-auth credentials embedded in the GOPROXY url',
-    async (t) => {
-      t.equal(
-        buildDistributionUrl(
-          'golang.org/x/text',
-          'v0.3.2',
-          'https://foo:bar@corp.example.com/goproxy/',
-        ),
-        'https://corp.example.com/goproxy/golang.org/x/text/@v/v0.3.2.zip',
-        'credentials must never end up in component metadata',
-      );
-    },
-  );
+  t.test('reduces submodule and /vN paths to the repo root', async (t) => {
+    t.equal(
+      buildVcsUrl('github.com/foo/bar/v2', undefined),
+      'https://github.com/foo/bar',
+      'the semantic-import-versioning suffix is dropped',
+    );
+    t.equal(
+      buildVcsUrl('github.com/foo/bar/submodule', undefined),
+      'https://github.com/foo/bar',
+      'a submodule path resolves to its repo root',
+    );
+  });
+
+  t.test('returns undefined for a vanity path with no origin', async (t) => {
+    // The public proxy serves no origin metadata, and rsc.io does not map to a
+    // repo root — so rather than guess a wrong URL, emit nothing.
+    t.equal(buildVcsUrl('rsc.io/quote', undefined), undefined);
+    t.equal(buildVcsUrl('golang.org/x/text', undefined), undefined);
+  });
+
+  t.test('ignores a non-http(s) origin url', async (t) => {
+    t.equal(
+      buildVcsUrl('github.com/foo/bar', 'git@github.com:foo/bar.git'),
+      'https://github.com/foo/bar',
+      'falls back to the path heuristic for ssh/scp remotes',
+    );
+    t.equal(
+      buildVcsUrl('example.com/mod', 'ssh://git@git.example.com/mod'),
+      undefined,
+      'no http(s) origin and no known host -> no label',
+    );
+  });
 });
 
 test('getComponentMetadataLabels', async (t) => {
-  t.test(
-    'emits hash and distribution url when the module hash is known',
-    async (t) => {
-      const labels = getComponentMetadataLabels(
-        'golang.org/x/text',
-        'v0.3.2',
-        H1,
-        undefined,
-      );
-      t.strictSame(labels, {
-        'hash:sha-256': H1_HEX,
-        'distribution:url':
-          'https://proxy.golang.org/golang.org/x/text/@v/v0.3.2.zip',
-      });
-    },
-  );
+  t.test('emits hash and vcs url when both are known', async (t) => {
+    const labels = getComponentMetadataLabels(
+      'github.com/pkg/errors',
+      H1,
+      undefined,
+    );
+    t.strictSame(labels, {
+      'hash:sha-256': H1_HEX,
+      'vcs:url': 'https://github.com/pkg/errors',
+    });
+  });
 
   t.test('omits the hash when the module has no hash', async (t) => {
     const labels = getComponentMetadataLabels(
-      'golang.org/x/text',
-      'v0.3.2',
+      'github.com/pkg/errors',
       undefined,
       undefined,
     );
     t.strictSame(labels, {
-      'distribution:url':
-        'https://proxy.golang.org/golang.org/x/text/@v/v0.3.2.zip',
+      'vcs:url': 'https://github.com/pkg/errors',
     });
   });
 
-  t.test('omits the url when GOPROXY offers nothing to derive', async (t) => {
+  t.test('omits the vcs url when it cannot be resolved', async (t) => {
     const labels = getComponentMetadataLabels(
       'golang.org/x/text',
-      'v0.3.2',
       H1,
-      'off',
+      undefined,
     );
     t.strictSame(labels, { 'hash:sha-256': H1_HEX });
   });

--- a/test/go-standard-library-packages.test.ts
+++ b/test/go-standard-library-packages.test.ts
@@ -82,9 +82,6 @@ test('std-lib packages carry no component-metadata labels', async (t) => {
   for (const node of stdNodes) {
     const labels = node.info?.labels || {};
     t.notOk(labels['hash:sha-256'], `${node.pkgId} has no hash:sha-256 label`);
-    t.notOk(
-      labels['distribution:url'],
-      `${node.pkgId} has no distribution:url label`,
-    );
+    t.notOk(labels['vcs:url'], `${node.pkgId} has no vcs:url label`);
   }
 });


### PR DESCRIPTION
## What & why

Go retains **no** record of which `GOPROXY` entry served a given module (verified against the toolchain: no `Origin` for proxy fetches, nothing in the module cache identifying the serving proxy). So a proxy-derived `distribution:url` cannot be attributed reliably, and for private proxy setups it risks shipping a non-portable — potentially credential-bearing — URL in component metadata.

This replaces the `distribution:url` component-metadata label with **`vcs:url`**, the module's source repository, which is stable provenance.

## How it resolves the VCS URL (best-effort, hybrid)

1. **go's own `Origin` metadata** (the VCS URL), read directly from the module cache `.info` file that sits next to `Module.GoMod`. Authoritative, and resolves vanity paths (`rsc.io/quote` → `https://github.com/rsc/quote`). This is a plain on-disk read of the already-populated cache — **no network, no extra `go` invocation**. Only present for `direct` (or origin-serving-proxy) fetches; `proxy.golang.org` serves no origin data.
2. **Otherwise, derive `host/owner/repo`** from the module path for well-known VCS hosts (`github.com`, `gitlab.com`, `bitbucket.org`), correctly reducing submodule (`.../sub`) and `/vN` suffixes to the repo root.

Emits **no** label when neither resolves (e.g. a vanity path fetched via a proxy) rather than guessing a wrong URL. Origin URLs are still credential-stripped as defence in depth.

## Notes
- Drops the `go env GOPROXY` plumbing that fed the old label. The credential-stripping added in #149 is now moot for the proxy URL (it is no longer emitted), so this effectively supersedes that concern.
- `hash:sha-256` label behaviour is unchanged.

## Testing
- `component-metadata.test.ts` — rewritten for `buildVcsUrl` / `vcs:url` (origin preference, credential + trailing-slash stripping, host heuristic, submodule/`vN` reduction, vanity-path omission, non-http origin fallback).
- `component-metadata-graph.test.ts` — asserts `vcs:url` on the go-modules graph.
- `go-standard-library-packages.test.ts` — stdlib nodes carry no `vcs:url`.
- `tsc`, `eslint`, and all three suites (115 asserts) green locally.